### PR TITLE
junitreport: Expose classpath and factory of internal XSLTProcess task.

### DIFF
--- a/manual/Tasks/junitreport.html
+++ b/manual/Tasks/junitreport.html
@@ -167,6 +167,15 @@ These tags can pass XSL parameters to the stylesheet.
   </tr>
 </table>
 
+<h4>classpath</h4>
+<p><em>Since Ant 1.10.</em>
+Like for the <a href="../CoreTasks/style.html#classpath">XSLT task</a>,
+a nested &lt;classpath&gt; will be used to load the processor.</p>
+
+<h4>factory</h4>
+<p><em>Since Ant 1.10.</em>
+Like for the <a href="../CoreTasks/style.html#factory">XSLT task</a>,
+a nested &lt;factory&gt; can be used to specify factory settings.</p>
 
 
 <h3>Example of report</h3>

--- a/manual/Tasks/style.html
+++ b/manual/Tasks/style.html
@@ -269,7 +269,7 @@ collection</a></h4>
 should be applied to.  Use a nested mapper and the task's destdir
 attribute to specify the output files.</p>
 
-<h4>classpath</h4>
+<h4><a name="classpath">classpath</a></h4>
 <p>The classpath to load the processor from can be specified via a
 nested <code>&lt;classpath&gt;</code>, as well - that is, a
 <a href="../using.html#path">path</a>-like structure.</p>
@@ -372,7 +372,7 @@ XSLT specifications</a>.
 </table>
 </blockquote>
 
-<h4>factory ('trax' processors only)</h4>
+<h4><a name="factory">factory ('trax' processors only)</a></h4>
 Used to specify factory settings.
 <blockquote>
 <h4>Parameters</h4>

--- a/src/main/org/apache/tools/ant/taskdefs/optional/junit/AggregateTransformer.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/junit/AggregateTransformer.java
@@ -37,6 +37,7 @@ import org.apache.tools.ant.taskdefs.Delete;
 import org.apache.tools.ant.taskdefs.TempFile;
 import org.apache.tools.ant.taskdefs.XSLTProcess;
 import org.apache.tools.ant.types.EnumeratedAttribute;
+import org.apache.tools.ant.types.Path;
 import org.apache.tools.ant.types.Resource;
 import org.apache.tools.ant.types.resources.FileResource;
 import org.apache.tools.ant.types.resources.URLResource;
@@ -90,11 +91,11 @@ public class AggregateTransformer {
     protected File toDir;
 
     /**
-     * The params that will be sent to the XSL transformation
+     * The internal XSLT task used to perform the transformation.
      *
-     * @since Ant 1.7
+     * @since Ant 1.10
      */
-    private List params;
+    private XSLTProcess xsltTask;
 
     /**
      * Instance of a utility class to use for file operations.
@@ -129,7 +130,8 @@ public class AggregateTransformer {
      */
     public AggregateTransformer(Task task) {
         this.task = task;
-        params = new Vector();
+        xsltTask = new XSLTProcess();
+        xsltTask.bindToOwner(task);
     }
 
     /**
@@ -209,9 +211,27 @@ public class AggregateTransformer {
      * @since Ant 1.7
      */
     public XSLTProcess.Param createParam() {
-        XSLTProcess.Param p = new XSLTProcess.Param();
-        params.add(p);
-        return p;
+        return xsltTask.createParam();
+    }
+
+    /**
+     * Creates a classpath to be used for the internal XSLT task.
+     *
+     * @return the classpath to be configured
+     * @since Ant 1.10
+     */
+    public Path createClasspath() {
+        return xsltTask.createClasspath();
+    }
+
+    /**
+     * Creates a factory configuration to be used for the internal XSLT task.
+     *
+     * @return the factory description to be configured
+     * @since Ant 1.10
+     */
+    public XSLTProcess.Factory createFactory() {
+        return xsltTask.createFactory();
     }
 
     /**
@@ -224,9 +244,6 @@ public class AggregateTransformer {
 
         TempFile tempFileTask = new TempFile();
         tempFileTask.bindToOwner(task);
-
-        XSLTProcess xsltTask = new XSLTProcess();
-        xsltTask.bindToOwner(task);
 
         xsltTask.setXslResource(getStylesheet());
 
@@ -245,13 +262,6 @@ public class AggregateTransformer {
             outputFile = new File(toDir, "junit-noframes.html");
         }
         xsltTask.setOut(outputFile);
-        for (Iterator i = params.iterator(); i.hasNext();) {
-            XSLTProcess.Param param = (XSLTProcess.Param) i.next();
-            XSLTProcess.Param newParam = xsltTask.createParam();
-            newParam.setProject(task.getProject());
-            newParam.setName(param.getName());
-            newParam.setExpression(param.getExpression());
-        }
         XSLTProcess.Param paramx = xsltTask.createParam();
         paramx.setProject(task.getProject());
         paramx.setName("output.dir");


### PR DESCRIPTION
Trying to revive [bug 47002](https://issues.apache.org/bugzilla/show_bug.cgi?id=47002) by filing a pull request for it.

This patch creates the nested XSLTProcess at creation of the
AggregateTransformer, not upon execution of the transformation.  This way it
is much easier to simply wrap parts of the interface I'd like to expose,
like the new <classpath> and <factory> nested elements, but also the
existing <param> elements.

I haven't called XSLTProcess.init(), as the previous code didn't do that
either.  I don't fully understand the difference between init() and a
constructor, but it might be a good thing to init the task somewhere.

The approach I chose is something like a whitelist delegation: the
XSLTProcess is a private member, and only selected methods of its interface
are wrapped and thus exposed to be configured.  As an alternative, one could
do something like a blacklist delegation by deriving a class from
XSLTProcess and forbidding access to certain settings by ovverriding the
corresponding methods and throwing exceptions therein.  In that case, one
might even turn the class derived from XSLTProcess into a nested <xslt>
element, which would be probably much clearer, as it would be configured in
the same way that a top-level <xslt> task is.  I didn't choose this approach
in my patch for now.
