### PR TITLE
Clean up whitespace in build.xml example

### DIFF
--- a/manual/using.html
+++ b/manual/using.html
@@ -172,7 +172,7 @@ task instances at all, only proxies.
   &lt;!-- set global properties for this build --&gt;
   &lt;property name=&quot;src&quot; location=&quot;src&quot;/&gt;
   &lt;property name=&quot;build&quot; location=&quot;build&quot;/&gt;
-  &lt;property name=&quot;dist&quot;  location=&quot;dist&quot;/&gt;
+  &lt;property name=&quot;dist&quot; location=&quot;dist&quot;/&gt;
 
   &lt;target name=&quot;init&quot;&gt;
     &lt;!-- Create the time stamp --&gt;

--- a/manual/using.html
+++ b/manual/using.html
@@ -166,9 +166,9 @@ task instances at all, only proxies.
 <h3><a name="example">Example Buildfile</a></h3>
 <pre>
 &lt;project name=&quot;MyProject&quot; default=&quot;dist&quot; basedir=&quot;.&quot;&gt;
-    &lt;description&gt;
-        simple example build file
-    &lt;/description&gt;
+  &lt;description&gt;
+    simple example build file
+  &lt;/description&gt;
   &lt;!-- set global properties for this build --&gt;
   &lt;property name=&quot;src&quot; location=&quot;src&quot;/&gt;
   &lt;property name=&quot;build&quot; location=&quot;build&quot;/&gt;
@@ -182,13 +182,13 @@ task instances at all, only proxies.
   &lt;/target&gt;
 
   &lt;target name=&quot;compile&quot; depends=&quot;init&quot;
-        description=&quot;compile the source &quot; &gt;
+        description=&quot;compile the source&quot;&gt;
     &lt;!-- Compile the java code from ${src} into ${build} --&gt;
     &lt;javac srcdir=&quot;${src}&quot; destdir=&quot;${build}&quot;/&gt;
   &lt;/target&gt;
 
   &lt;target name=&quot;dist&quot; depends=&quot;compile&quot;
-        description=&quot;generate the distribution&quot; &gt;
+        description=&quot;generate the distribution&quot;&gt;
     &lt;!-- Create the distribution directory --&gt;
     &lt;mkdir dir=&quot;${dist}/lib&quot;/&gt;
 
@@ -197,7 +197,7 @@ task instances at all, only proxies.
   &lt;/target&gt;
 
   &lt;target name=&quot;clean&quot;
-        description=&quot;clean up&quot; &gt;
+        description=&quot;clean up&quot;&gt;
     &lt;!-- Delete the ${build} and ${dist} directory trees --&gt;
     &lt;delete dir=&quot;${build}&quot;/&gt;
     &lt;delete dir=&quot;${dist}&quot;/&gt;


### PR DESCRIPTION
The original author did a good job making readable xml using the HTML escape syntax, but I just noticed a few stray spaces when I copied the build.xml to start my own project.

Before:

![before](https://cloud.githubusercontent.com/assets/2244895/6435093/00249b76-c064-11e4-9752-6db64fed0e18.png)

After:

![after](https://cloud.githubusercontent.com/assets/2244895/6435089/f2ff2830-c063-11e4-877e-588d2b56b2c3.png)

