### PR TITLE
increase buffer size to improve transfer speed

### DIFF
--- a/src/main/org/apache/tools/ant/taskdefs/optional/ssh/ScpToMessage.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/ssh/ScpToMessage.java
@@ -36,7 +36,7 @@ import com.jcraft.jsch.Session;
 public class ScpToMessage extends AbstractSshMessage {
 
     private static final int HUNDRED_KILOBYTES = 102400;
-    private static final int BUFFER_SIZE = 1024;
+    private static final int BUFFER_SIZE = 100*1024;
 
     private File localFile;
     private String remotePath;


### PR DESCRIPTION
1024 byte buffer size is insufficient for transfering large files over faster (> 100Mbit) networks. We are transfering files tens or hundreds MB in size and transfer speed was 1MB/s. After increasing the buffer size too 100KB we are getting transfer speeds up to 60MB/s. Please consider increasing the BUFFER_SIZE in the next Ant release. Thanks, Peter