### PR TITLE
JDK 9 drops Java 1.5 so bumped to Java 1.6

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -104,8 +104,8 @@
   <property name="chmod.maxparallel" value="250"/>
   <property name="deprecation" value="false"/>
   <property name="optimize" value="true"/>
-  <property name="javac.target" value="1.5"/>
-  <property name="javac.source" value="1.5"/>
+  <property name="javac.target" value="1.6"/>
+  <property name="javac.source" value="1.6"/>
   <property name="junit.filtertrace" value="off"/>
   <property name="junit.summary" value="no"/>
   <property name="test.haltonfailure" value="false"/>


### PR DESCRIPTION
Java 9 Early Access Build 99, builds successfully when java change to 1.6 from 1.5

Other things might also need to change, but the build is successful. JavaDoc throws issues but completes okay.