### PR TITLE
JDK9 modules support for JUnitTask

### DIFF
--- a/manual/Tasks/junit.html
+++ b/manual/Tasks/junit.html
@@ -840,7 +840,7 @@ The <code>-XaddExports</code> java option makes the non-exported test package <c
     &lt;junit fork="true"
         jvm="${platform.java}"&gt;
         &lt;jvmarg line="-addmods ${test.module.name}"/&gt;
-        &lt;jvmarg value="-XaddExports:${test.module.name}/my.test=junit"/&gt;
+        &lt;jvmarg value="-XaddExports:${test.module.name}/my.test=junit,ALL-UNNAMED"/&gt;
         &lt;modulepath&gt;
             &lt;pathelement path="${modules}:${build.classes}:${libs.junit}"/&gt;
         &lt;/modulepath&gt;
@@ -851,7 +851,7 @@ The <code>-XaddExports</code> java option makes the non-exported test package <c
 <p>Runs my.test.TestCase as a black-box test in the forked VM given by the <code>platform.java</code> property.
 The junit library is used as an automatic module. The tests module-info requires the tested module and junit.<br/>
 The <code>-addmods</code> java option enables the test module.<br/>
-The <code>-XaddExports</code> java option makes the non-exported test package <code>my.test</code> accessible from the junit module.
-Another possibility is to export the test package in the tests module-info by <code>exports my.test</code> directive<br/>
+The <code>-XaddExports</code> java option makes the non-exported test package <code>my.test</code> accessible from the junit module and Ant's test runner.
+Another possibility is to export the test package in the tests module-info by <code>exports my.test</code> directive.<br/>
 </body>
 </html>

--- a/manual/Tasks/junit.html
+++ b/manual/Tasks/junit.html
@@ -371,6 +371,21 @@ subelement.</p>
 
 <p><em>since Ant 1.6.</em></p>
 
+<h4>modulepath</h4>
+
+<p>The location of modules can be specified using this <a href="../using.html#path">PATH like structure</a>.<br/>
+The modulepath requires <i>fork</i> to be set to <code>true</code>.
+
+<p><em>since Ant 1.10</em></p>
+
+<h4>upgrademodulepath</h4>
+
+<p>The location of modules that replace upgradeable modules in the runtime image
+can be specified using this <a href="../using.html#path">PATH like structure</a>.<br/>
+The upgrademodulepath requires <i>fork</i> to be set to <code>true</code>.
+
+<p><em>since Ant 1.10</em></p>
+
 <h4>formatter</h4>
 
 <p>The results of the tests can be printed in different
@@ -796,7 +811,47 @@ the single <code>&lt;test/&gt;</code> will run. So only the failing test cases a
 The two nested formatters are for displaying (for the user) and for updating the collector
 class.
 </p>
-
-
+<pre>
+    &lt;junit fork="true"
+        jvm="${platform.java}"&gt;
+        &lt;jvmarg value="-Xpatch:${module.name}=${build.test.classes}"/&gt;
+        &lt;jvmarg line="-addmods ${module.name}"/&gt;
+        &lt;jvmarg value="-XaddReads:${module.name}=ALL-UNNAMED"/&gt;
+        &lt;jvmarg value="-XaddExports:${module.name}/my.test=ALL-UNNAMED"/&gt;
+        &lt;classpath&gt;
+            &lt;pathelement path="${libs.junit}"/&gt;
+        &lt;/classpath&gt;
+        &lt;modulepath&gt;
+            &lt;pathelement path="${modules}:${build.classes}"/&gt;
+        &lt;/modulepath&gt;
+        &lt;formatter type="plain"/&gt;
+        &lt;test name="my.test.TestCase"/&gt;
+    &lt;/junit&gt;
+</pre>
+<p>Runs my.test.TestCase as a white-box test in the forked VM given by the <code>platform.java</code> property.
+The junit library is a part of an unnamed module while the tested project and required modules are on the module path. The tests
+do not have module-info file and are executed in the project module given by <code>module.name</code> property.<br/>
+The <code>-Xpatch</code> java option executes the tests built into <code>${build.test.classes}</code> in a module given
+by <code>module.name</code> property.<br/>
+The <code>-addmods</code> java option enables the tested module.<br/>
+The <code>-XaddReads</code> java option makes the unnamed module containing the junit readable by tested module.<br/>
+The <code>-XaddExports</code> java option makes the non-exported test package <code>my.test</code> accessible from the unnamed module containing the junit.<br/>
+<pre>
+    &lt;junit fork="true"
+        jvm="${platform.java}"&gt;
+        &lt;jvmarg line="-addmods ${test.module.name}"/&gt;
+        &lt;jvmarg value="-XaddExports:${test.module.name}/my.test=junit"/&gt;
+        &lt;modulepath&gt;
+            &lt;pathelement path="${modules}:${build.classes}:${libs.junit}"/&gt;
+        &lt;/modulepath&gt;
+        &lt;formatter type="plain"/&gt;
+        &lt;test name="my.test.TestCase"/&gt;
+    &lt;/junit&gt;
+</pre>
+<p>Runs my.test.TestCase as a black-box test in the forked VM given by the <code>platform.java</code> property.
+The junit library is used as an automatic module. The tests module-info requires the tested module and junit.<br/>
+The <code>-addmods</code> java option enables the test module.<br/>
+The <code>-XaddExports</code> java option makes the non-exported test package <code>my.test</code> accessible from the junit module.
+Another possibility is to export the test package in the tests module-info by <code>exports my.test</code> directive<br/>
 </body>
 </html>

--- a/src/main/org/apache/tools/ant/taskdefs/optional/junit/JUnitTask.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/junit/JUnitTask.java
@@ -1749,7 +1749,8 @@ public class JUnitTask extends Task {
                 path,
                 true)) {
             try {
-                return loader.getResource("junit.framework.Test") != null;
+                loader.loadClass("junit.framework.Test");
+                return true;
             } catch (final Exception ex) {
                 return false;
             }

--- a/src/main/org/apache/tools/ant/taskdefs/optional/junit/JUnitTask.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/junit/JUnitTask.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Vector;
@@ -1766,7 +1767,7 @@ public class JUnitTask extends Task {
         for (String path : modulePath.list()) {
             final File modulePathEntry = getProject().resolveFile(path);
             if (modulePathEntry.isDirectory() && !hasModuleInfo(modulePathEntry)) {
-                final File[] modules = modulePathEntry.listFiles((dir,name)->name.toLowerCase().endsWith(".jar"));
+                final File[] modules = modulePathEntry.listFiles((dir,name)->name.toLowerCase(Locale.ENGLISH).endsWith(".jar"));
                 if (modules != null) {
                     for (File module : modules) {
                         expanded.add(new Path(getProject(), String.format(


### PR DESCRIPTION
Changes:
1.  Added modulepath and upgrademodulepath elements.
2. When modulepath or upgrademodulepath is given VM fork is required.
3. JUnit library required by Ant is searched both on classpath and modulepath.

As seen in [JUnitTask + JDK9 question thread](http://mail-archives.apache.org/mod_mbox/ant-dev/201604.mbox/%3CAFE6C849-0622-44D1-9FF7-3A6CA4832F82%40oracle.com%3E) there are many ways how to write and execute unit test in the JDK9 involving several java options (`-addmods`, `-Xpatch`, `-XaddExports`, `-XaddReads`). 

The JunitTask can 
1. Keep the responsibility on user to correctly specify these options. The disadvantage of these solution is the complexity of VM options.
2. Automatically add the VM options. The disadvantage of these solution is that it’s impossible to cover all scenarios and there needs to be a way how to disable it. Also the options may change in time, for example if junit becomes a named module.

Currently the patch contains the 1st. solution. 
Thanks for comments!