### PR TITLE
JDK9 command line options updated to JEP 293

### DIFF
--- a/manual/Tasks/junit.html
+++ b/manual/Tasks/junit.html
@@ -814,10 +814,10 @@ class.
 <pre>
     &lt;junit fork="true"
         jvm="${platform.java}"&gt;
-        &lt;jvmarg value="-Xpatch:${module.name}=${build.test.classes}"/&gt;
-        &lt;jvmarg line="-addmods ${module.name}"/&gt;
-        &lt;jvmarg value="-XaddReads:${module.name}=ALL-UNNAMED"/&gt;
-        &lt;jvmarg value="-XaddExports:${module.name}/my.test=ALL-UNNAMED"/&gt;
+        &lt;jvmarg line="--patch-module ${module.name}=${build.test.classes}"/&gt;
+        &lt;jvmarg line="--add-modules ${module.name}"/&gt;
+        &lt;jvmarg line="--add-reads ${module.name}=ALL-UNNAMED"/&gt;
+        &lt;jvmarg line="--add-exports ${module.name}/my.test=ALL-UNNAMED"/&gt;
         &lt;classpath&gt;
             &lt;pathelement path="${libs.junit}"/&gt;
         &lt;/classpath&gt;
@@ -831,16 +831,16 @@ class.
 <p>Runs my.test.TestCase as a white-box test in the forked VM given by the <code>platform.java</code> property.
 The junit library is a part of an unnamed module while the tested project and required modules are on the module path. The tests
 do not have module-info file and are executed in the project module given by <code>module.name</code> property.<br/>
-The <code>-Xpatch</code> java option executes the tests built into <code>${build.test.classes}</code> in a module given
+The <code>--patch-module</code> java option executes the tests built into <code>${build.test.classes}</code> in a module given
 by <code>module.name</code> property.<br/>
-The <code>-addmods</code> java option enables the tested module.<br/>
-The <code>-XaddReads</code> java option makes the unnamed module containing the junit readable by tested module.<br/>
-The <code>-XaddExports</code> java option makes the non-exported test package <code>my.test</code> accessible from the unnamed module containing the junit.<br/>
+The <code>--add-modules</code> java option enables the tested module.<br/>
+The <code>--add-reads</code> java option makes the unnamed module containing the junit readable by tested module.<br/>
+The <code>--add-exports</code> java option makes the non-exported test package <code>my.test</code> accessible from the unnamed module containing the junit.<br/>
 <pre>
     &lt;junit fork="true"
         jvm="${platform.java}"&gt;
-        &lt;jvmarg line="-addmods ${test.module.name}"/&gt;
-        &lt;jvmarg value="-XaddExports:${test.module.name}/my.test=junit,ALL-UNNAMED"/&gt;
+        &lt;jvmarg line="--add-modules ${test.module.name}"/&gt;
+        &lt;jvmarg line="--add-exports ${test.module.name}/my.test=junit,ALL-UNNAMED"/&gt;
         &lt;modulepath&gt;
             &lt;pathelement path="${modules}:${build.classes}:${libs.junit}"/&gt;
         &lt;/modulepath&gt;
@@ -850,8 +850,8 @@ The <code>-XaddExports</code> java option makes the non-exported test package <c
 </pre>
 <p>Runs my.test.TestCase as a black-box test in the forked VM given by the <code>platform.java</code> property.
 The junit library is used as an automatic module. The tests module-info requires the tested module and junit.<br/>
-The <code>-addmods</code> java option enables the test module.<br/>
-The <code>-XaddExports</code> java option makes the non-exported test package <code>my.test</code> accessible from the junit module and Ant's test runner.
+The <code>--add-modules</code> java option enables the test module.<br/>
+The <code>--add-exports</code> java option makes the non-exported test package <code>my.test</code> accessible from the junit module and Ant's test runner.
 Another possibility is to export the test package in the tests module-info by <code>exports my.test</code> directive.<br/>
 </body>
 </html>

--- a/src/main/org/apache/tools/ant/taskdefs/compilers/DefaultCompilerAdapter.java
+++ b/src/main/org/apache/tools/ant/taskdefs/compilers/DefaultCompilerAdapter.java
@@ -401,12 +401,12 @@ public abstract class DefaultCompilerAdapter
         }
         final Path msp = getModulesourcepath();
         if (msp.size() > 0) {
-            cmd.createArgument().setValue("-modulesourcepath");
+            cmd.createArgument().setValue("--module-source-path");
             cmd.createArgument().setPath(msp);
         }
         final Path mp = getModulepath();
         if (mp.size() > 0) {
-            cmd.createArgument().setValue("-modulepath");
+            cmd.createArgument().setValue("--module-path");
             cmd.createArgument().setPath(mp);
         }
         final Path ump = getUpgrademodulepath();

--- a/src/main/org/apache/tools/ant/types/CommandlineJava.java
+++ b/src/main/org/apache/tools/ant/types/CommandlineJava.java
@@ -520,13 +520,13 @@ public class CommandlineJava implements Cloneable {
         }
         //module path
         if (haveModulepath()) {
-            listIterator.add("-modulepath");
+            listIterator.add("--module-path");
             listIterator.add(
                     modulepath.concatSystemClasspath("ignore").toString());
         }
         //upgrade module path
         if (haveUpgrademodulepath()) {
-            listIterator.add("-upgrademodulepath");
+            listIterator.add("--upgrade-module-path");
             listIterator.add(
                     upgrademodulepath.concatSystemClasspath("ignore").toString());
         }

--- a/src/tests/junit/org/apache/tools/ant/taskdefs/compilers/DefaultCompilerAdapterTest.java
+++ b/src/tests/junit/org/apache/tools/ant/taskdefs/compilers/DefaultCompilerAdapterTest.java
@@ -250,13 +250,13 @@ public class DefaultCompilerAdapterTest {
             Assert.assertNotNull(cmd[0]);
             final List<String> cmdLine = Arrays.asList(cmd[0].getCommandline());
             //No modulesourcepath
-            assertEquals(-1, cmdLine.indexOf("-modulesourcepath"));
+            assertEquals(-1, cmdLine.indexOf("--module-source-path"));
             //The -sourcepath has to be followed by src
             int index = cmdLine.indexOf("-sourcepath");
             Assert.assertTrue(index != -1 && index < cmdLine.size() - 1);
             assertEquals(src.getAbsolutePath(), cmdLine.get(index + 1));
-            //The -modulepath has to be followed by modules
-            index = cmdLine.indexOf("-modulepath");
+            //The --module-path has to be followed by modules
+            index = cmdLine.indexOf("--module-path");
             Assert.assertTrue(index != -1 && index < cmdLine.size() - 1);
             assertEquals(modules.getAbsolutePath(), cmdLine.get(index + 1));
             //J1.java & J2.java has to be in files list
@@ -310,8 +310,8 @@ public class DefaultCompilerAdapterTest {
             final List<String> cmdLine = Arrays.asList(cmd[0].getCommandline());
             //No sourcepath
             assertEquals(-1, cmdLine.indexOf("-sourcepath"));
-            //The -modulesourcepath has to be followed by the pattern
-            int index = cmdLine.indexOf("-modulesourcepath");
+            //The --module-source-path has to be followed by the pattern
+            int index = cmdLine.indexOf("--module-source-path");
             Assert.assertTrue(index != -1 && index < cmdLine.size() - 1);
             String expectedModSrcPath = String.format("%s/%s",
                     workDir.getAbsolutePath(),
@@ -319,8 +319,8 @@ public class DefaultCompilerAdapterTest {
                     .replace('/', File.separatorChar)
                     .replace('\\', File.separatorChar);
             assertEquals(expectedModSrcPath, cmdLine.get(index + 1));
-            //The -modulepath has to be followed by modules
-            index = cmdLine.indexOf("-modulepath");
+            //The --module-path has to be followed by modules
+            index = cmdLine.indexOf("--module-path");
             Assert.assertTrue(index != -1 && index < cmdLine.size() - 1);
             assertEquals(modules.getAbsolutePath(), cmdLine.get(index + 1));
             //J1.java, J2.java & J3.java has to be in files list

--- a/src/tests/junit/org/apache/tools/ant/taskdefs/optional/junit/JUnitTaskTest.java
+++ b/src/tests/junit/org/apache/tools/ant/taskdefs/optional/junit/JUnitTaskTest.java
@@ -476,10 +476,10 @@ public class JUnitTaskTest {
             for (int i = 1; i< mockProcLauncher.cmd.length; i++) {
                 if ("-classpath".equals(mockProcLauncher.cmd[i])) { //NOI18N
                     resCp = mockProcLauncher.cmd[++i];
-                } else if ("-modulepath".equals(mockProcLauncher.cmd[i])) { //NOI18N
+                } else if ("--module-path".equals(mockProcLauncher.cmd[i])) { //NOI18N
                     resMp = mockProcLauncher.cmd[++i];
-                } else if (mockProcLauncher.cmd[i].startsWith("-XaddExports:")) {   //NOI18N
-                    resExports.add(mockProcLauncher.cmd[i]);
+                } else if (mockProcLauncher.cmd[i].equals("--add-exports")) {   //NOI18N
+                    resExports.add(mockProcLauncher.cmd[++i]);
                 } else if (JUnitTestRunner.class.getName().equals(mockProcLauncher.cmd[i])) {
                     break;
                 }
@@ -530,10 +530,10 @@ public class JUnitTaskTest {
             for (int i = 1; i< mockProcLauncher.cmd.length; i++) {
                 if ("-classpath".equals(mockProcLauncher.cmd[i])) { //NOI18N
                     resCp = mockProcLauncher.cmd[++i];
-                } else if ("-modulepath".equals(mockProcLauncher.cmd[i])) { //NOI18N
+                } else if ("--module-path".equals(mockProcLauncher.cmd[i])) { //NOI18N
                     resMp = mockProcLauncher.cmd[++i];
-                } else if (mockProcLauncher.cmd[i].startsWith("-XaddExports:")) {   //NOI18N
-                    resExports.add(mockProcLauncher.cmd[i]);
+                } else if (mockProcLauncher.cmd[i].equals("--add-exports")) {   //NOI18N
+                    resExports.add(mockProcLauncher.cmd[++i]);
                 } else if (JUnitTestRunner.class.getName().equals(mockProcLauncher.cmd[i])) {
                     break;
                 }


### PR DESCRIPTION
The JDK9 command line options updated to [JEP-293](http://openjdk.java.net/jeps/293) - Guidelines for JDK Command-Line Tool Options.
Options introduced before the  JDK 9 will continue to exist in the old format, eg. -classpath, -cp and a new format is added: --class-path.
The options introduced in the JDK 9 were updated to the new format, eg. --module-path, -p.

This pull request updates the JDK 9 options used in the Ant to the new format.