### PR TITLE
Fixed forgotten -upgrademodulepath in the DefaultCompilerAdapter - follow pull request #21

### DIFF
--- a/src/main/org/apache/tools/ant/taskdefs/compilers/DefaultCompilerAdapter.java
+++ b/src/main/org/apache/tools/ant/taskdefs/compilers/DefaultCompilerAdapter.java
@@ -411,7 +411,7 @@ public abstract class DefaultCompilerAdapter
         }
         final Path ump = getUpgrademodulepath();
         if (ump.size() > 0) {
-            cmd.createArgument().setValue("-upgrademodulepath");
+            cmd.createArgument().setValue("--upgrade-module-path");
             cmd.createArgument().setPath(ump);
         }
         if (attributes.getNativeHeaderDir() != null) {


### PR DESCRIPTION
In the #21 I've overlooked one "-upgrademodulepath" in the DefaultCompilerAdapter.
Sorry for that. This pull request fixes the forgotten "-upgrademodulepath".

