### PR TITLE
corrected comments

### DIFF
--- a/src/script/ant
+++ b/src/script/ant
@@ -50,13 +50,13 @@ for arg in "$@" ; do
 
     # wrap all arguments as "" strings, escape any internal back-slash, double-quote, $, or back-tick characters
     #  use printf to avoid echo interpretation behaviors such as escapes and line continuation
-    #  pad the value with leading/trailing X to protect whitespace
+    #  pad the value with X to protect leading/trailing whitespace from subshell output trimming
     esc_arg="X${arg}X"
     case "$esc_tool" in
       'sed')
         # Mac bsd_sed does not support group-0, so pattern uses group-1
         # Solaris sed only proceses lines with trailing newline, passing in an extra newline
-        # sed will consume the trailing newline
+        # subshell assignment will trim the added trailing newline
         esc_arg="$(printf '%s\n' "$esc_arg" | sed -e 's@\([$"\\`]\)@\\\1@g')"
         ;;
       'awk')


### PR DESCRIPTION
Finally figured out why some behaviors were present. Originally thought sed was trimming whitespace in its output.
I had not known that subshell output capture via either `` or "$()" trims whitespace from the ends.

I updated the comments to specifically mention subshell trimming as the reason for needing the padding and why the \n is not an issue.

Makes me feel much better about x-platform robustness of this now that I understand these behaviors were not related to sed version quirks.

Obviously this is just cosmetic.