### PR TITLE
Bug 58661: avoid duplicate characters in stack traces

### DIFF
--- a/src/etc/junit-frames.xsl
+++ b/src/etc/junit-frames.xsl
@@ -930,13 +930,13 @@ h6 {
 <xsl:template name="br-replace">
     <xsl:param name="word"/>
     <xsl:param name="splitlimit">32</xsl:param>
-    <xsl:variable name="secondhalflen" select="(string-length($word)+(string-length($word) mod 2)) div 2"/>
-    <xsl:variable name="secondhalfword" select="substring($word, $secondhalflen)"/>
+    <xsl:variable name="secondhalfstartindex" select="(string-length($word)+(string-length($word) mod 2)) div 2"/>
+    <xsl:variable name="secondhalfword" select="substring($word, $secondhalfstartindex)"/>
     <!-- When word is very big, a recursive replace is very heap/stack expensive, so subdivide on line break after middle of string -->
     <xsl:choose>
       <xsl:when test="(string-length($word) > $splitlimit) and (contains($secondhalfword, '&#xa;'))">
         <xsl:variable name="secondhalfend" select="substring-after($secondhalfword, '&#xa;')"/>
-        <xsl:variable name="firsthalflen" select="string-length($word) - $secondhalflen"/>
+        <xsl:variable name="firsthalflen" select="string-length($word) - string-length($secondhalfword)"/>
         <xsl:variable name="firsthalfword" select="substring($word, 1, $firsthalflen)"/>
         <xsl:variable name="firsthalfend" select="substring-before($secondhalfword, '&#xa;')"/>
         <xsl:call-template name="br-replace">

--- a/src/etc/junit-noframes.xsl
+++ b/src/etc/junit-noframes.xsl
@@ -470,13 +470,13 @@
 <xsl:template name="br-replace">
     <xsl:param name="word"/>
     <xsl:param name="splitlimit">32</xsl:param>
-    <xsl:variable name="secondhalflen" select="(string-length($word)+(string-length($word) mod 2)) div 2"/>
-    <xsl:variable name="secondhalfword" select="substring($word, $secondhalflen)"/>
+    <xsl:variable name="secondhalfstartindex" select="(string-length($word)+(string-length($word) mod 2)) div 2"/>
+    <xsl:variable name="secondhalfword" select="substring($word, $secondhalfstartindex)"/>
     <!-- When word is very big, a recursive replace is very heap/stack expensive, so subdivide on line break after middle of string -->
     <xsl:choose>
       <xsl:when test="(string-length($word) > $splitlimit) and (contains($secondhalfword, '&#xa;'))">
         <xsl:variable name="secondhalfend" select="substring-after($secondhalfword, '&#xa;')"/>
-        <xsl:variable name="firsthalflen" select="string-length($word) - $secondhalflen"/>
+        <xsl:variable name="firsthalflen" select="string-length($word) - string-length($secondhalfword)"/>
         <xsl:variable name="firsthalfword" select="substring($word, 1, $firsthalflen)"/>
         <xsl:variable name="firsthalfend" select="substring-before($secondhalfword, '&#xa;')"/>
         <xsl:call-template name="br-replace">


### PR DESCRIPTION
This fixes https://bz.apache.org/bugzilla/show_bug.cgi?id=58661

As suspected, the problem is in the 'br-replace' template that is off by one character in some cases:
$secondhalflen is actually less than string-length($secondhalfword) in case the number of chars in word is
even. This leads to $firsthalflen being calculated too long, resulting in a duplicated character.

Note that unlike the patch attached to the bug, this pull requests solves just the duplicate character problem - nothing else.