### PR TITLE
Add Orion EJB deployment tool to EjbJar taskdef.

### DIFF
--- a/manual/Tasks/ejb.html
+++ b/manual/Tasks/ejb.html
@@ -61,6 +61,8 @@ In general these tasks are specific to the particular vendor's EJB Server.</p>
   Application Server 6.0</li>
   <li><a href="http://www.jboss.org/" target="_top">
   JBoss 2.1</a> and above EJB servers</li>
+  <li><a href="http://web.archive.org/web/20080516210506/http://www.ironflare.com/">
+  Orion Application Server</a> 2.0</li>
   <li><a href="http://www.bea.com" target="_top">Weblogic</a>
    4.5.1 through to 7.0 EJB servers</li>
   <li><a href="http://www.objectweb.org/jonas/" target="_top">JOnAS</a>
@@ -81,14 +83,15 @@ In general these tasks are specific to the particular vendor's EJB Server.</p>
  <tr><td>Task</td><td colspan="2">Application Servers</td></tr>
  <tr><td><a href="BorlandGenerateClient.html">blgenclient</a></td><td colspan="2">Borland Application Server 4.5 and 5.x</td></tr>
  <tr><td><a href="#iplanet-ejbc">iplanet-ejbc</a></td><td colspan="2">iPlanet Application Server 6.0</td></tr>
- <tr><td rowspan="7"><a href="#ejbjar">ejbjar</a></td><td colspan="2" align="center"><b>Nested Elements</b></td></tr>
+ <tr><td rowspan="8"><a href="#ejbjar">ejbjar</a></td><td colspan="2" align="center"><b>Nested Elements</b></td></tr>
  <tr><td><a href="BorlandEJBTasks.html">borland</a></td><td>Borland Application Server 4.5 and 5.x</td></tr>
  <tr><td><a href="#ejbjar_iplanet">iPlanet</a></td><td>iPlanet Application Server 6.0</td></tr>
  <tr><td><a href="#ejbjar_jboss">jboss</a></td><td>JBoss</td></tr>
  <tr><td><a href="#ejbjar_jonas">jonas</a></td><td>JOnAS 2.4.x and 2.5</td></tr>
  <tr><td><a href="#ejbjar_weblogic">weblogic</a></td><td>Weblogic 5.1 to 7.0</td></tr>
  <tr><td><a href="#ejbjar_websphere">websphere</a></td><td>IBM WebSphere 4.0</td></tr>
- 
+ <tr><td><a href="#ejbjar_orion">orion</a></td><td>IronFlare(Oracle) Orion Application Server 2.0.6</td></tr>
+
 </table>
 
 <hr>
@@ -562,6 +565,7 @@ include: </p>
   <li>IBM WebSphere 4.0</li>
   <li>TOPLink for WebLogic 2.5.1-enabled entity beans</li>
   <li><a href="http://www.objectweb.org/jonas/">JOnAS</a> 2.4.x and 2.5 Open Source EJB server</li>
+  <li>IronFlare Orion Application Server 2.0</li>
 </ul>
 
 
@@ -1770,7 +1774,42 @@ descriptors to use the naming standard. This will create only one ejb jar file -
 </pre>
 
 
+<h3><a name="ejbjar_orion">Orion element</a></h3>
 
+<p>The orion element searches for the Orion Application Server specific deployment descriptors and adds them
+to the final ejb jar file. Orion has one deployment descriptor:
+<ul><li>orion-ejb-jar.xml</li>
+</ul>
+<br>
+<table border="1" cellpadding="2" cellspacing="0">
+  <tr>
+    <td valign="top"><b>Attribute</b></td>
+    <td valign="top"><b>Description</b></td>
+    <td align="center" valign="top"><b>Required</b></td>
+  </tr>
+  <tr>
+    <td valign="top">destdir</td>
+    <td valign="top">The base directory into which the generated 
+                     jar files are deposited. Jar files are deposited in
+                     directories corresponding to their location within the
+                     descriptordir namespace. </td>
+    <td valign="top" align="center">Yes</td>
+  </tr>
+</table>
+
+<h3>Example</h3>
+
+<pre>
+      &lt;ejbjar srcdir="${build.classes}"
+              descriptordir="${descriptor.dir}"
+              basejarname="TheEJBJar"
+              flatdestdir="true"
+              dependency="super"
+              genericjarsuffix=".jar"&gt;
+        &lt;include name="**/*-ejb-jar.xml"/&gt;
+        &lt;orion destdir="${deploymentjars.dir}"\&gt;
+      &lt;/ejbjar&gt;
+</pre>
 
 </body>
 

--- a/src/main/org/apache/tools/ant/taskdefs/optional/ejb/EjbJar.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/ejb/EjbJar.java
@@ -222,6 +222,18 @@ public class EjbJar extends MatchingTask {
     }
 
     /**
+     * Create a orion nested element used to configure a
+     * deployment tool for Orion server.
+     *
+     * @return the deployment tool instance to be configured.
+     */
+    public OrionDeploymentTool createOrion() {
+        OrionDeploymentTool tool = new OrionDeploymentTool();
+        addDeploymentTool(tool);
+        return tool;
+    }
+
+    /**
      * Adds a deployment tool for Weblogic server.
      *
      * @return the deployment tool instance to be configured.

--- a/src/main/org/apache/tools/ant/taskdefs/optional/ejb/OrionDeploymentTool.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/ejb/OrionDeploymentTool.java
@@ -1,68 +1,33 @@
 /*
- * The Apache Software License, Version 1.1
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
  *
- * Copyright (c) 2000 The Apache Software Foundation.  All rights
- * reserved.
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- *
- * 3. The end-user documentation included with the redistribution, if
- *    any, must include the following acknowlegement:
- *       "This product includes software developed by the
- *        Apache Software Foundation (http://www.apache.org/)."
- *    Alternately, this acknowlegement may appear in the software itself,
- *    if and wherever such third-party acknowlegements normally appear.
- *
- * 4. The names "The Jakarta Project", "Ant", and "Apache Software
- *    Foundation" must not be used to endorse or promote products derived
- *    from this software without prior written permission. For written
- *    permission, please contact apache@apache.org.
- *
- * 5. Products derived from this software may not be called "Apache"
- *    nor may "Apache" appear in their names without prior written
- *    permission of the Apache Group.
- *
- * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED.  IN NO EVENT SHALL THE APACHE SOFTWARE FOUNDATION OR
- * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
- * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
- * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
- * ====================================================================
- *
- * This software consists of voluntary contributions made by many
- * individuals on behalf of the Apache Software Foundation.  For more
- * information on the Apache Software Foundation, please see
- * <http://www.apache.org/>.
  */
+
 package org.apache.tools.ant.taskdefs.optional.ejb;
 
-import java.io.*;
-import java.util.*;
-import org.apache.tools.ant.*;
+import java.io.File;
+import java.util.Hashtable;
+import org.apache.tools.ant.Project;
 
 /**
  * The deployment tool to add the orion specific deployment descriptor to the 
  * ejb jar file. Orion only requires one additional file orion-ejb-jar.xml 
  * and does not require any additional compilation.
  *
- * @author <a href="mailto:atul.setlur@med.ge.com">Atul Setlur</a>
+ * @author <a href="mailto:mark.niggemann@ge.com">Mark Niggemann</a>
  * @version 1.0
  * @see EjbJar#createOrion
  */

--- a/src/main/org/apache/tools/ant/taskdefs/optional/ejb/OrionDeploymentTool.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/ejb/OrionDeploymentTool.java
@@ -1,0 +1,102 @@
+/*
+ * The Apache Software License, Version 1.1
+ *
+ * Copyright (c) 2000 The Apache Software Foundation.  All rights
+ * reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The end-user documentation included with the redistribution, if
+ *    any, must include the following acknowlegement:
+ *       "This product includes software developed by the
+ *        Apache Software Foundation (http://www.apache.org/)."
+ *    Alternately, this acknowlegement may appear in the software itself,
+ *    if and wherever such third-party acknowlegements normally appear.
+ *
+ * 4. The names "The Jakarta Project", "Ant", and "Apache Software
+ *    Foundation" must not be used to endorse or promote products derived
+ *    from this software without prior written permission. For written
+ *    permission, please contact apache@apache.org.
+ *
+ * 5. Products derived from this software may not be called "Apache"
+ *    nor may "Apache" appear in their names without prior written
+ *    permission of the Apache Group.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED.  IN NO EVENT SHALL THE APACHE SOFTWARE FOUNDATION OR
+ * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ */
+package org.apache.tools.ant.taskdefs.optional.ejb;
+
+import java.io.*;
+import java.util.*;
+import org.apache.tools.ant.*;
+
+/**
+ * The deployment tool to add the orion specific deployment descriptor to the 
+ * ejb jar file. Orion only requires one additional file orion-ejb-jar.xml 
+ * and does not require any additional compilation.
+ *
+ * @author <a href="mailto:atul.setlur@med.ge.com">Atul Setlur</a>
+ * @version 1.0
+ * @see EjbJar#createOrion
+ */
+
+public class OrionDeploymentTool extends GenericDeploymentTool {
+    
+    protected static final String ORION_DD = "orion-ejb-jar.xml";
+    
+
+    /** Instance variable that stores the suffix for the jboss jarfile. */
+    private String jarSuffix = ".jar";
+
+    /**
+     * Add any vendor specific files which should be included in the
+     * EJB Jar.
+     */
+    protected void addVendorFiles(Hashtable ejbFiles, String baseName) {
+        String ddPrefix = (usingBaseJarName() ? "" : baseName );
+        File orionDD = new File(getConfig().descriptorDir, ddPrefix + ORION_DD);
+        
+        if (orionDD.exists()) {
+            ejbFiles.put(META_DIR + ORION_DD, orionDD);
+        } else {
+            log("Unable to locate Orion deployment descriptor. It was expected to be in " + orionDD.getPath(), Project.MSG_WARN);
+            return;
+        }
+        
+    }
+
+    /**
+     * Get the vendor specific name of the Jar that will be output. The modification date
+     * of this jar will be checked against the dependent bean classes.
+     */
+    File getVendorOutputJarFile(String baseName) {
+        return new File(getDestDir(), baseName + jarSuffix);
+    }
+}


### PR DESCRIPTION
This taskdef is used to support legacy Orion Application Server EJB deployment. We've been applying it as patch to ANT for several years now and it would simplify life to contribute the changes back to the community. 

BTW, this taskdef should also work for Oracle OC4J, but I do not have license to that product to verify it.