### PR TITLE
[1.9.x branch] BZ-60644 Fix file corruption during copy task

### DIFF
--- a/src/etc/testcases/taskdefs/copy.xml
+++ b/src/etc/testcases/taskdefs/copy.xml
@@ -265,4 +265,31 @@ a=b=
     </fail>
   </target>
 
+  <target name="setupSelfCopyTesting" description="Sets up the necessary files and directories for testSelfCopy task which
+                will be called by the test cases">
+    <property name="self.copy.test.root.dir" location="${output}/self-copy-test"/>
+    <mkdir dir="${self.copy.test.root.dir}"/>
+    <echo file="${self.copy.test.root.dir}/file.txt" message="hello-world"/>
+  </target>
+
+  <target name="testSelfCopy">
+    <property name="self.copy.test.root.dir" location="${output}/self-copy-test"/>
+    <!-- straightforward self-copy -->
+    <copy file="${self.copy.test.root.dir}/file.txt" tofile="${self.copy.test.root.dir}/file.txt" overwrite="true"/>
+
+    <!-- create a symlink of the source file and then attempt a copy of the original file and the symlink -->
+    <symlink link="${self.copy.test.root.dir}/sylmink-file.txt" resource="${self.copy.test.root.dir}/file.txt"/>
+    <copy file="${self.copy.test.root.dir}/file.txt" tofile="${self.copy.test.root.dir}/sylmink-file.txt" overwrite="true"/>
+    <copy file="${self.copy.test.root.dir}/sylmink-file.txt" tofile="${self.copy.test.root.dir}/file.txt" overwrite="true"/>
+
+    <!-- create a symlink of the dir containing the source file and then attempt a copy of the original file and the symlink dir -->
+    <property name="self.copy.test.symlinked.dir" location="${output}/symlink-for-output-dir"/>
+    <symlink link="${self.copy.test.symlinked.dir}" resource="${self.copy.test.root.dir}"/>
+    <copy file="${self.copy.test.symlinked.dir}/file.txt" tofile="${self.copy.test.root.dir}/sylmink-file.txt" overwrite="true"/>
+    <copy file="${self.copy.test.root.dir}/sylmink-file.txt" tofile="${self.copy.test.symlinked.dir}/file.txt" overwrite="true"/>
+
+    <copy todir="${self.copy.test.symlinked.dir}" overwrite="true">
+      <fileset dir="${self.copy.test.root.dir}"/>
+    </copy>
+  </target>
 </project>


### PR DESCRIPTION
The commit here includes a fix for the issue reported in https://bz.apache.org/bugzilla/show_bug.cgi?id=60644. As described in that issue, the copy task corrupts the source file(s) that's being copied in cases where the target file points back to the source file through symlink.

The commit here (intentionally) handles/fixes this issue in core/central location and not just in the Copy task so that all such copy operations (through the `ResourceUtils`) now have the safeguard to ensure that such copying doesn't cause the source file corruption and the copying itself is skipped if the source and destination are the same resource.

This commit also includes a testcase to verify and fix the issue.

This PR is against the 1.9.x branch. Once tested, approved and merged, I can make corresponding PR/commits to the master branch to fix it there too.

P.S: Given that this change is in a central location (the `ResourceUtils`), for obvious reasons, this PR will have to run past the complete set of tests before being merged.
