### PR TITLE
[1.9.x branch] BZ-58589 Preserve last modified time (if asked for) for files uploaded by SFTP

### DIFF
--- a/src/main/org/apache/tools/ant/taskdefs/optional/ssh/Scp.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/ssh/Scp.java
@@ -354,7 +354,7 @@ public class Scp extends SSHBase {
                                                list, file, preserveLastModified);
                 } else {
                     message = new ScpToMessageBySftp(getVerbose(), session,
-                                                     list, file);
+                                                     list, file, preserveLastModified);
                 }
                 message.setLogListener(this);
                 if (fileMode != null) {
@@ -389,7 +389,7 @@ public class Scp extends SSHBase {
                 message =
                     new ScpToMessageBySftp(getVerbose(), session,
                                            getProject().resolveFile(fromPath),
-                                           file);
+                                           file, preserveLastModified);
             }
             message.setLogListener(this);
             if (fileMode != null) {


### PR DESCRIPTION
The commit here adds support for preserving the last modified time on files when uploaded via SFTP, as requested in https://bz.apache.org/bugzilla/show_bug.cgi?id=58589:

> Do you think you could also modify ScpToMessageBySftp?

The commit has been manually tested to make sure it doesn't cause regressions and does indeed preserve the timestamp if asked for.