### PR TITLE
Fix the problem of instanceof test always return true.

### DIFF
--- a/src/main/org/apache/tools/ant/types/resources/comparators/Reverse.java
+++ b/src/main/org/apache/tools/ant/types/resources/comparators/Reverse.java
@@ -83,7 +83,7 @@ public class Reverse extends ResourceComparator {
         if (isReference()) {
             super.dieOnCircularReference(stk, p);
         } else {
-            if (nested instanceof DataType) {
+            if (nested != null) {
                 pushAndInvokeCircularReferenceCheck((DataType) nested, stk,
                                                     p);
             }


### PR DESCRIPTION
This instanceof test will always return true because DataType is the superclass of variable nested's class ResourceComparator. The variable nested is not initialized, it would be better to do a null test rather than an instanceof test.
http://findbugs.sourceforge.net/bugDescriptions.html#BC_VACUOUS_INSTANCEOF