### PR TITLE
Fix the inefficient use of keySet iterator with entrySet iterator.

### DIFF
--- a/src/main/org/apache/tools/ant/filters/ReplaceTokens.java
+++ b/src/main/org/apache/tools/ant/filters/ReplaceTokens.java
@@ -116,8 +116,8 @@ public final class ReplaceTokens
 
         if (!resolvedTokensBuilt) {
             // build the resolved tokens tree map.
-            for (String key : hash.keySet()) {
-                resolvedTokens.put(beginToken + key + endToken, hash.get(key));
+            for (Map.Entry<String, String> entry : hash.entrySet()) {
+                resolvedTokens.put(beginToken + entry.getKey() + endToken, entry.getValue());
             }
             resolvedTokensBuilt = true;
         }

--- a/src/main/org/apache/tools/ant/taskdefs/Move.java
+++ b/src/main/org/apache/tools/ant/taskdefs/Move.java
@@ -105,8 +105,9 @@ public class Move extends Copy {
     protected void doFileOperations() {
         //Attempt complete directory renames, if any, first.
         if (completeDirMap.size() > 0) {
-            for (File fromDir : completeDirMap.keySet()) {
-                File toDir = completeDirMap.get(fromDir);
+            for (Map.Entry<File, File> entry : completeDirMap.entrySet()) {
+                File fromDir = entry.getKey();
+                File toDir = entry.getValue();
                 boolean renamed = false;
                 try {
                     log("Attempting to rename dir: " + fromDir + " to " + toDir, verbosity);
@@ -133,11 +134,12 @@ public class Move extends Copy {
             log("Moving " + moveCount + " file" + ((moveCount == 1) ? "" : "s")
                     + " to " + destDir.getAbsolutePath());
 
-            for (String fromFile : fileCopyMap.keySet()) {
+            for (Map.Entry<String, String[]> entry : fileCopyMap.entrySet) {
+                String fromFile = entry.getKey();
                 File f = new File(fromFile);
                 boolean selfMove = false;
                 if (f.exists()) { //Is this file still available to be moved?
-                    String[] toFiles = fileCopyMap.get(fromFile);
+                    String[] toFiles = entry.getValue();
                     for (int i = 0; i < toFiles.length; i++) {
                         String toFile = toFiles[i];
 
@@ -164,8 +166,9 @@ public class Move extends Copy {
 
         if (includeEmpty) {
             int createCount = 0;
-            for (String fromDirName : dirCopyMap.keySet()) {
-                String[] toDirNames = dirCopyMap.get(fromDirName);
+            for (Map<String, String[]> entry : dirCopyMap.entrySet()) {
+                String fromDirName = entry.getKey();
+                String[] toDirNames = entry.getValue();;
                 boolean selfMove = false;
                 for (int i = 0; i < toDirNames.length; i++) {
                     if (fromDirName.equals(toDirNames[i])) {

--- a/src/main/org/apache/tools/ant/taskdefs/optional/ejb/GenericDeploymentTool.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/ejb/GenericDeploymentTool.java
@@ -760,11 +760,12 @@ public class GenericDeploymentTool implements EJBDeploymentTool {
                 jarStream.setMethod(JarOutputStream.DEFLATED);
 
                 // Loop through all the class files found and add them to the jar
-                for (String entryName : files.keySet()) {
+                for (Map.Entry<String, File> entryFiles : files.entrySet()) {
+                    String entryName = entryFiles.getKey();
                     if (entryName.equals(MANIFEST)) {
                         continue;
                     }
-                    File entryFile = files.get(entryName);
+                    File entryFile = entryFiles.getValue();
                     log("adding file '" + entryName + "'", Project.MSG_VERBOSE);
                     addFileToJar(jarStream, entryFile, entryName);
 


### PR DESCRIPTION

The current source code accesses the key and value of a Hashtable entry, using a key that is retrieved from a keySet iterator.
It is more efficient to use an iterator on the entrySet of the Hashtable, to avoid the Map.get(key) lookup.
http://findbugs.sourceforge.net/bugDescriptions.html#WMI_WRONG_MAP_ITERATOR