### PR TITLE
Fix the problem of using '+=' operator to concatenate strings in a loop

### DIFF
--- a/src/main/org/apache/tools/ant/Main.java
+++ b/src/main/org/apache/tools/ant/Main.java
@@ -1284,9 +1284,9 @@ public class Main implements AntMain {
         // now, start printing the targets and their descriptions
         final String lSep = System.getProperty("line.separator");
         // got a bit annoyed that I couldn't find a pad function
-        String spaces = "    ";
+        StringBuilder spaces = new StringBuilder("    ");
         while (spaces.length() <= maxlen) {
-            spaces += spaces;
+            spaces.append(spaces);
         }
         final StringBuilder msg = new StringBuilder();
         msg.append(heading).append(lSep).append(lSep);


### PR DESCRIPTION
The method is building a String using concatenation in a loop.
In each iteration, the String is converted to a StringBuilder, appended to, and converted back to a String.
This can lead to a cost quadratic in the number of iterations, as the growing string is recopied in each iteration.
Better performance can be obtained by using a StringBuilder explicitly.
http://findbugs.sourceforge.net/bugDescriptions.html#SBSC_USE_STRINGBUFFER_CONCATENATION