### PR TITLE
Consider returning a zero length array rather than null.

### DIFF
--- a/src/main/org/apache/tools/ant/taskdefs/Execute.java
+++ b/src/main/org/apache/tools/ant/taskdefs/Execute.java
@@ -229,7 +229,7 @@ public class Execute {
         }
         // MAC OS 9 and previous
         // TODO: I have no idea how to get it, someone must fix it
-        return null;
+        return new String[0];
     }
 
     /**

--- a/src/main/org/apache/tools/ant/types/Environment.java
+++ b/src/main/org/apache/tools/ant/types/Environment.java
@@ -155,7 +155,7 @@ public class Environment {
      */
     public String[] getVariables() throws BuildException {
         if (variables.isEmpty()) {
-            return null;
+            return new String[0];
         }
         return variables.stream().map(Variable::getContent).toArray(String[]::new);
     }


### PR DESCRIPTION
It is often a better design to return a length zero array rather than a null reference to indicate that there are no results (i.e., an empty list of results).
This way, no explicit check for null is needed by clients of the method.
On the other hand, using null to indicate "there is no answer to this question" is probably appropriate.
http://findbugs.sourceforge.net/bugDescriptions.html#PZLA_PREFER_ZERO_LENGTH_ARRAYS