### PR TITLE
BZ-61718 Upgrade to 0.1.54 of Jsch library

### DIFF
--- a/lib/libraries.properties
+++ b/lib/libraries.properties
@@ -46,7 +46,7 @@ jasper-runtime.version=${jasper-compiler.version}
 jdepend.version=2.9.1
 jruby.version=0.9.8
 junit.version=4.11
-jsch.version=0.1.50
+jsch.version=0.1.54
 jython.version=2.1
 #log4j 1.2.15 requires JMS and a few other Sun jars that are not in the m2 repo
 log4j.version=1.2.14

--- a/manual/install.html
+++ b/manual/install.html
@@ -1007,7 +1007,7 @@ you need jakarta-oro 2.0.8 or later, and <a href="#commons-net">commons-net</a><
     target="_top">http://xml.apache.org/commons/</a>.</td>
   </tr>
   <tr>
-    <td>jsch.jar <b>0.1.50 or later</b></td>
+    <td>jsch.jar <b>0.1.54 or later</b></td>
     <td>sshexec and scp tasks</td>
     <td><a href="http://www.jcraft.com/jsch/index.html"
         target="_top">http://www.jcraft.com/jsch/index.html</a></td>

--- a/src/etc/poms/ant-jsch/pom.xml
+++ b/src/etc/poms/ant-jsch/pom.xml
@@ -46,7 +46,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/ma
     <dependency>
       <groupId>com.jcraft</groupId>
       <artifactId>jsch</artifactId>
-      <version>0.1.50</version>
+      <version>0.1.54</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
The commit here upgrades Jsch library dependency to `0.1.54` (which is the latest released version) as requested in https://bz.apache.org/bugzilla/show_bug.cgi?id=61718. This PR is against 1.9.x branch and if approved, I'll merge the change to master branch too.
