### PR TITLE
[master branch] - Fix BZ-58683 

### DIFF
--- a/WHATSNEW
+++ b/WHATSNEW
@@ -17,15 +17,20 @@ Fixed bugs:
  * bootstrapping Ant on Windows failed
    Bugzilla Report 61027
 
- * Bugzilla Reports 59648 and 43271 - Fixed the issue where the 
-   SCP based tasks would try to change the permissions on the
-   parent directory of a transferred file, instead of changing it
-   on the transferred file itself.
+ * Fixed the issue where the SCP based tasks would try to change 
+   the permissions on the parent directory of a transferred file,
+   instead of changing it on the transferred file itself.
+   Bugzilla Reports 59648 and 43271
 
- * Bugzilla Report 60644 - Fixed the issue where the source file
-   being copied could end up being corrupted if the target of the
-   copy happened to be the same source file (symlinked back
-   to itself).
+ * Fixed the issue where the source file being copied could end 
+   up being corrupted if the target of the copy happened to be 
+   the same source file (symlinked back to itself).
+   Bugzilla Report 60644
+
+ * Fixed the issue where symlink creation with "overwrite=false",
+   on existing symlink whose target was a directory, would end 
+   up creating a new symlink under the target directory.
+   Bugzilla Report 58683
 
 Other changes:
 --------------

--- a/manual/Tasks/symlink.html
+++ b/manual/Tasks/symlink.html
@@ -26,10 +26,10 @@
 
 <h2><a name="symlink">Symlink</a></h2>
 <h3>Description</h3>
-<p> Manages symbolic links on Unix based platforms. Can be used to
-make an individual link, delete a link, create multiple links from properties files, 
-or create properties files describing links in the specified directories.
-Existing links are not overwritten by default.
+<p> Manages symbolic links on platforms where Java supports symbolic links.
+Can be used to make an individual link, delete a link, create multiple links 
+from properties files, or create properties files describing links in the 
+specified directories. Existing links are not overwritten by default.
 
 <p><a href="../Types/fileset.html">FileSet</a>s are used to select a
 set of links to record, or a set of property files to create links from. </p>
@@ -127,18 +127,8 @@ set of links to record, or a set of property files to create links from. </p>
   variable to an absolute path, which will remove the /some/working/directory portion
   of the above path and allow ant to find the correct commandline execution script.
  
-  <p><strong>LIMITATIONS:</strong> Because Java has no direct support for
-  handling symlinks this task divines them by comparing canonical and
-  absolute paths. On non-unix systems this may cause false positives.
-  Furthermore, any operating system on which the command
-  <code>ln -s &lt;linkname&gt; &lt;resourcename&gt;</code> is not a valid 
-  command on the command line will not be able to use action="single" or 
-  action="recreate". Action="record" and action=delete should still work. Finally, 
-  the lack of support for symlinks in Java means that all links are recorded as 
-  links to the <strong>canonical</strong> resource name. Therefore the link:
-  <code>link --> subdir/dir/../foo.bar</code> will be recorded as
-  <code>link=subdir/foo.bar</code> and restored as
-  <code>link --> subdir/foo.bar</code></p>
+  <p><strong>NOTE:</strong> Starting Ant version 1.10.2, this task relies on the symbolic
+    link support introduced in Java 7 through the java.nio.file.Files APIs</p>
 
 
 

--- a/src/etc/testcases/taskdefs/optional/unix/symlink.xml
+++ b/src/etc/testcases/taskdefs/optional/unix/symlink.xml
@@ -302,7 +302,7 @@
 
     <sleep seconds="${delay}"/>  <!-- make sure OS has time to do the execs -->
 
-    <symlink action="recreate">
+    <symlink action="recreate" overwrite="true">
       <fileset dir="${output}/symtest1" includes="**/recorded.links"/>
     </symlink>
 
@@ -350,5 +350,17 @@
       <delete file="${output}/file2"/>
   </target>
 
+  <target name="test-overwrite-link" depends="setUp">
+    <mkdir dir="${output}/test-overwrite"/>
+    <mkdir dir="${output}/test-overwrite/dir1"/>
+    <property name="test.overwrite.link.target.dir" location="${output}/test-overwrite/dir1"/>
+    <!-- Create a symlink to the dir, this should work fine -->
+    <symlink link="${output}/test-overwrite/symlinked1" resource="${test.overwrite.link.target.dir}"/>
+    <!-- Create a symlink at the previously created symlink path with overwrite = false.
+      This *shouldn't* create a new link (within the target resource). See https://bz.apache.org/bugzilla/show_bug.cgi?id=58683 -->
+    <symlink link="${output}/test-overwrite/symlinked1" resource="${test.overwrite.link.target.dir}"/>
+
+
+  </target>
 
 </project>

--- a/src/tests/junit/org/apache/tools/ant/taskdefs/optional/unix/SymlinkTest.java
+++ b/src/tests/junit/org/apache/tools/ant/taskdefs/optional/unix/SymlinkTest.java
@@ -35,6 +35,7 @@ import org.apache.tools.ant.taskdefs.condition.Os;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.util.SymbolicLinkUtils;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
@@ -46,6 +47,9 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * Test cases for the Symlink task. Link creation, link deletion, recording
@@ -285,6 +289,26 @@ public class SymlinkTest {
         assertTrue(su.isDanglingSymbolicLink(f.getParentFile(),
                                              f.getName()));
 
+    }
+
+    /**
+     * Tests that when {@code symlink} task is used to create a symbolic link and {@code overwrite} option
+     * is {@code false}, then any existing symbolic link at the {@code link} location (whose target is a directory)
+     * doesn't end up create a new symbolic link within the target directory.
+     *
+     *
+     * @throws Exception
+     * @see <a href="https://bz.apache.org/bugzilla/show_bug.cgi?id=58683">BZ-58683</a> for more details
+     */
+    @Test
+    public void testOverwriteExistingLink() throws Exception {
+        buildRule.executeTarget("test-overwrite-link");
+        final Project p = buildRule.getProject();
+        final String linkTargetResource = p.getProperty("test.overwrite.link.target.dir");
+        Assert.assertNotNull("Property test.overwrite.link.target.dir is not set", linkTargetResource);
+        final Path targetResourcePath = Paths.get(linkTargetResource);
+        Assert.assertTrue(targetResourcePath + " is not a directory", Files.isDirectory(targetResourcePath));
+        Assert.assertEquals(targetResourcePath + " directory was expected to be empty", 0, Files.list(targetResourcePath).count());
     }
 
     @After


### PR DESCRIPTION
The commit here fixes the issue reported at https://bz.apache.org/bugzilla/show_bug.cgi?id=58683.

This commit along with fixing the issue reported in that bug, also has updated the `Symlink` task to now start relying on the Java 7 support of symlinking through the use of `java.nio.file.Files` APIs. This now allows the task to move away from spawning process(es) for dealing with symlinks and also allows this task to be functional on non-unix systems which support symbolic links.

P.S: For 1.9.x branch, I can create a separate commit, without using Java 7 APIs to fix this bug, if we do want to do that there. Let me know.
