### PR TITLE
[master] Changes for BZ-19516 

### DIFF
--- a/WHATSNEW
+++ b/WHATSNEW
@@ -32,6 +32,11 @@ Fixed bugs:
    up creating a new symlink under the target directory.
    Bugzilla Report 58683
 
+ * Improvement to the Zip task for reduced memory usage in certain
+   cases. Thanks to Glen Lewis for reporting the issue and 
+   suggesting the fix.
+   Bugzilla Report 19516
+
 Other changes:
 --------------
 


### PR DESCRIPTION
As suggested in https://bz.apache.org/bugzilla/show_bug.cgi?id=19516, the change in this PR uses `java.io.BufferedInputStream` which can take an underlying `InputStream` and provide `mark` support on the input stream. This should prevent loading a large amount of data into memory, in certain cases, in the `Zip` task.

If this PR is approved, I'll then backport this pretty straightforward change to 1.9.x branch too.

