### PR TITLE
Use equals method of a string literal to prevent NPE and isEmpty() me…

### DIFF
--- a/src/main/org/apache/tools/ant/helper/ProjectHelper2.java
+++ b/src/main/org/apache/tools/ant/helper/ProjectHelper2.java
@@ -667,8 +667,8 @@ public class ProjectHelper2 extends ProjectHelper {
         @Override
         public AntHandler onStartChild(String uri, String name, String qname, Attributes attrs,
                                        AntXMLContext context) throws SAXParseException {
-            if (name.equals("project")
-                && (uri.equals("") || uri.equals(ANT_CORE_URI))) {
+            if ("project".equals(name)
+                && (uri.isEmpty() || uri.equals(ANT_CORE_URI))) {
                 return ProjectHelper2.projectHandler;
             }
             if (name.equals(qname)) {
@@ -727,19 +727,19 @@ public class ProjectHelper2 extends ProjectHelper {
 
             for (int i = 0; i < attrs.getLength(); i++) {
                 String attrUri = attrs.getURI(i);
-                if (attrUri != null && !attrUri.equals("") && !attrUri.equals(uri)) {
+                if (attrUri != null && !attrUri.isEmpty() && !attrUri.equals(uri)) {
                     continue; // Ignore attributes from unknown uris
                 }
                 String key = attrs.getLocalName(i);
                 String value = attrs.getValue(i);
 
-                if (key.equals("default")) {
-                    if (value != null && !value.equals("")) {
+                if ("default".equals(key)) {
+                    if (value != null && !value.isEmpty()) {
                         if (!context.isIgnoringProjectTag()) {
                             project.setDefault(value);
                         }
                     }
-                } else if (key.equals("name")) {
+                } else if ("name".equals(key)) {
                     if (value != null) {
                         context.setCurrentProjectName(value);
                         nameAttributeSet = true;
@@ -754,14 +754,14 @@ public class ProjectHelper2 extends ProjectHelper {
                             }
                         }
                     }
-                } else if (key.equals("id")) {
+                } else if ("id".equals(key)) {
                     if (value != null) {
                         // What's the difference between id and name ?
                         if (!context.isIgnoringProjectTag()) {
                             project.addReference(value, project);
                         }
                     }
-                } else if (key.equals("basedir")) {
+                } else if ("basedir".equals(key)) {
                     if (!context.isIgnoringProjectTag()) {
                         baseDir = value;
                     }
@@ -864,8 +864,8 @@ public class ProjectHelper2 extends ProjectHelper {
         @Override
         public AntHandler onStartChild(String uri, String name, String qname, Attributes attrs,
                                        AntXMLContext context) throws SAXParseException {
-            return (name.equals("target") || name.equals("extension-point"))
-                && (uri.equals("") || uri.equals(ANT_CORE_URI))
+            return ("target".equals(name) || "extension-point".equals(name))
+                && (uri.isEmpty() || uri.equals(ANT_CORE_URI))
                 ? ProjectHelper2.targetHandler : ProjectHelper2.elementHandler;
         }
     }
@@ -912,32 +912,32 @@ public class ProjectHelper2 extends ProjectHelper {
 
             for (int i = 0; i < attrs.getLength(); i++) {
                 String attrUri = attrs.getURI(i);
-                if (attrUri != null && !attrUri.equals("") && !attrUri.equals(uri)) {
+                if (attrUri != null && !attrUri.isEmpty() && !attrUri.equals(uri)) {
                     continue; // Ignore attributes from unknown uris
                 }
                 String key = attrs.getLocalName(i);
                 String value = attrs.getValue(i);
 
-                if (key.equals("name")) {
+                if ("name".equals(key)) {
                     name = value;
-                    if ("".equals(name)) {
+                    if (name.isEmpty()) {
                         throw new BuildException("name attribute must " + "not be empty");
                     }
-                } else if (key.equals("depends")) {
+                } else if ("depends".equals(key)) {
                     depends = value;
-                } else if (key.equals("if")) {
+                } else if ("if".equals(key)) {
                     target.setIf(value);
-                } else if (key.equals("unless")) {
+                } else if ("unless".equals(key)) {
                     target.setUnless(value);
-                } else if (key.equals("id")) {
-                    if (value != null && !value.equals("")) {
+                } else if ("id".equals(key)) {
+                    if (value != null && !value.isEmpty()) {
                         context.getProject().addReference(value, target);
                     }
-                } else if (key.equals("description")) {
+                } else if ("description".equals(key)) {
                     target.setDescription(value);
-                } else if (key.equals("extensionOf")) {
+                } else if ("extensionOf".equals(key)) {
                     extensionPoint = value;
-                } else if (key.equals("onMissingExtensionPoint")) {
+                } else if ("onMissingExtensionPoint".equals(key)) {
                     try {
                         extensionPointMissing = OnMissingExtensionPoint.valueOf(value);
                     } catch (IllegalArgumentException e) {
@@ -1167,7 +1167,7 @@ public class ProjectHelper2 extends ProjectHelper {
             for (int i = 0; i < attrs.getLength(); i++) {
                 String name = attrs.getLocalName(i);
                 String attrUri = attrs.getURI(i);
-                if (attrUri != null && !attrUri.equals("") && !attrUri.equals(uri)) {
+                if (attrUri != null && !attrUri.isEmpty() && !attrUri.equals(uri)) {
                     name = attrUri + ":" + attrs.getQName(i);
                 }
                 String value = attrs.getValue(i);

--- a/src/main/org/apache/tools/ant/helper/ProjectHelperImpl.java
+++ b/src/main/org/apache/tools/ant/helper/ProjectHelperImpl.java
@@ -328,7 +328,7 @@ public class ProjectHelperImpl extends ProjectHelper {
          *                              <code>"project"</code>
          */
         public void startElement(String tag, AttributeList attrs) throws SAXParseException {
-            if (tag.equals("project")) {
+            if ("project".equals(tag)) {
                 new ProjectHandler(helperImpl, this).init(tag, attrs);
             } else {
                 throw new SAXParseException("Config file is not of expected " + "XML type",
@@ -389,13 +389,13 @@ public class ProjectHelperImpl extends ProjectHelper {
                 String key = attrs.getName(i);
                 String value = attrs.getValue(i);
 
-                if (key.equals("default")) {
+                if ("default".equals(key)) {
                     def = value;
-                } else if (key.equals("name")) {
+                } else if ("name".equals(key)) {
                     name = value;
-                } else if (key.equals("id")) {
+                } else if ("id".equals(key)) {
                     id = value;
-                } else if (key.equals("basedir")) {
+                } else if ("basedir".equals(key)) {
                     baseDir = value;
                 } else {
                     throw new SAXParseException(
@@ -404,7 +404,7 @@ public class ProjectHelperImpl extends ProjectHelper {
                 }
             }
 
-            if (def != null && !def.equals("")) {
+            if (def != null && !def.isEmpty()) {
                 helperImpl.project.setDefault(def);
             } else {
                 throw new BuildException("The default attribute is required");
@@ -455,7 +455,7 @@ public class ProjectHelperImpl extends ProjectHelper {
          *            or a data type definition
          */
         public void startElement(String name, AttributeList attrs) throws SAXParseException {
-            if (name.equals("target")) {
+            if ("target".equals(name)) {
                 handleTarget(name, attrs);
             } else {
                 handleElement(helperImpl, this, helperImpl.implicitTarget, name, attrs);
@@ -525,21 +525,21 @@ public class ProjectHelperImpl extends ProjectHelper {
                 String key = attrs.getName(i);
                 String value = attrs.getValue(i);
 
-                if (key.equals("name")) {
+                if ("name".equals(key)) {
                     name = value;
-                    if (name.equals("")) {
+                    if (name.isEmpty()) {
                         throw new BuildException("name attribute must not" + " be empty",
                                 new Location(helperImpl.locator));
                     }
-                } else if (key.equals("depends")) {
+                } else if ("depends".equals(key)) {
                     depends = value;
-                } else if (key.equals("if")) {
+                } else if ("if".equals(key)) {
                     ifCond = value;
-                } else if (key.equals("unless")) {
+                } else if ("unless".equals(key)) {
                     unlessCond = value;
-                } else if (key.equals("id")) {
+                } else if ("id".equals(key)) {
                     id = value;
-                } else if (key.equals("description")) {
+                } else if ("description".equals(key)) {
                     description = value;
                 } else {
                     throw new SAXParseException("Unexpected attribute \"" + key + "\"",
@@ -563,7 +563,7 @@ public class ProjectHelperImpl extends ProjectHelper {
             target.setDescription(description);
             helperImpl.project.addTarget(name, target);
 
-            if (id != null && !id.equals("")) {
+            if (id != null && !id.isEmpty()) {
                 helperImpl.project.addReference(id, target);
             }
 
@@ -600,7 +600,7 @@ public class ProjectHelperImpl extends ProjectHelper {
      */
     private static void handleElement(ProjectHelperImpl helperImpl, DocumentHandler parent,
             Target target, String elementName, AttributeList attrs) throws SAXParseException {
-        if (elementName.equals("description")) {
+        if ("description".equals(elementName)) {
             // created for side effect
             new DescriptionHandler(helperImpl, parent); //NOSONAR
         } else if (helperImpl.project.getDataTypeDefinitions().get(elementName) != null) {

--- a/src/main/org/apache/tools/ant/taskdefs/optional/ejb/JonasDeploymentTool.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/ejb/JonasDeploymentTool.java
@@ -615,13 +615,13 @@ public class JonasDeploymentTool extends GenericDeploymentTool {
         }
 
         // javacopts
-        if (javacopts != null && !javacopts.equals("")) {
+        if (javacopts != null && !javacopts.isEmpty()) {
             genicTask.createArg().setValue("-javacopts");
             genicTask.createArg().setLine(javacopts);
         }
 
         // rmicopts
-        if (rmicopts != null && !rmicopts.equals("")) {
+        if (rmicopts != null && !rmicopts.isEmpty()) {
             genicTask.createArg().setValue("-rmicopts");
             genicTask.createArg().setLine(rmicopts);
         }

--- a/src/main/org/apache/tools/ant/taskdefs/optional/net/FTP.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/net/FTP.java
@@ -506,7 +506,7 @@ public class FTP extends Task implements FTPTaskConfig {
                     return;
                 }
                 String completePath = null;
-                if (!vpath.equals("")) {
+                if (!vpath.isEmpty()) {
                     completePath = rootPath + remoteFileSep
                         + vpath.replace(File.separatorChar, remoteFileSep.charAt(0));
                 } else {
@@ -521,8 +521,8 @@ public class FTP extends Task implements FTPTaskConfig {
                 for (int i = 0; i < newfiles.length; i++) {
                     FTPFile file = newfiles[i];
                     if (file != null
-                        && !file.getName().equals(".")
-                        && !file.getName().equals("..")) {
+                        && !".".equals(file.getName())
+                        && !"..".equals(file.getName())) {
                         String name = vpath + file.getName();
                         scannedDirs.put(name, new FTPFileProxy(file));
                         if (isFunctioningAsDirectory(ftp, dir, file)) {
@@ -1536,7 +1536,7 @@ public class FTP extends Task implements FTPTaskConfig {
      * @see org.apache.commons.net.ftp.FTPClientConfig
      */
     public void setServerLanguageCodeConfig(LanguageCode serverLanguageCode) {
-        if (serverLanguageCode != null && !serverLanguageCode.getValue().equals("")) {
+        if (serverLanguageCode != null && !serverLanguageCode.getValue().isEmpty()) {
             this.serverLanguageCodeConfig = serverLanguageCode;
             configurationHasBeenSet();
         }


### PR DESCRIPTION
…thod instead of comparing a String object with an empty string.

This change has already been done for some locations in the commit:
https://github.com/apache/ant/commit/b7d1e9bde44cb8e5233d6e70bb96e14cbb2f3e2d