### PR TITLE
Fix NPE in ChainedMapper.

### DIFF
--- a/src/main/org/apache/tools/ant/util/ChainedMapper.java
+++ b/src/main/org/apache/tools/ant/util/ChainedMapper.java
@@ -18,6 +18,7 @@
 
 package org.apache.tools.ant.util;
 
+import java.util.Objects;
 import java.util.stream.Stream;
 
 /**
@@ -33,7 +34,7 @@ public class ChainedMapper extends ContainerMapper {
     public String[] mapFileName(String sourceFileName) {
         String[] result = getMappers().stream()
             .reduce(new String[] { sourceFileName }, (i, m) -> Stream.of(i)
-                .map(m::mapFileName).flatMap(Stream::of).toArray(String[]::new),
+                .map(m::mapFileName).filter(Objects::nonNull).flatMap(Stream::of).toArray(String[]::new),
                 (i, o) -> o);
         return result == null || result.length == 0 ? null : result;
     }

--- a/src/tests/junit/org/apache/tools/ant/types/MapperTest.java
+++ b/src/tests/junit/org/apache/tools/ant/types/MapperTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -224,6 +225,9 @@ public class MapperTest {
         List list = Arrays.asList(targets);
         assertTrue("cannot find expected target \"def\"", list.contains("def"));
         assertTrue("cannot find expected target \"ghi\"", list.contains("ghi"));
+
+        targets = fileNameMapper.mapFileName("z");
+        assertNull(targets);
     }
 
     @Test


### PR DESCRIPTION
This NPE happens whenever any of the sub mappers returns `null`, which may
happen eg. with `GlobPatternMapper`.