### PR TITLE
Add support for SAN extension in GenerateKey task

### DIFF
--- a/src/main/org/apache/tools/ant/taskdefs/GenerateKey.java
+++ b/src/main/org/apache/tools/ant/taskdefs/GenerateKey.java
@@ -187,7 +187,6 @@ public class GenerateKey extends Task {
     protected int keysize;
     protected int validity;
     protected boolean verbose;
-    private boolean useExtension;
     // CheckStyle:VisibilityModifier ON
 
     /**
@@ -231,7 +230,6 @@ public class GenerateKey extends Task {
     public void setSaname(final String saname) {
         if (JavaEnvUtils.isAtLeastJavaVersion(JavaEnvUtils.JAVA_1_7)) {
             this.saname = saname;
-            this.useExtension = true;
         } else {
             log("The SubjectAlternativeName extension is not available for "
                +"the Java Version being used.");
@@ -429,14 +427,11 @@ public class GenerateKey extends Task {
             sb.append("\" ");
         }
 
-        if (useExtension) {
+        if (null != saname) {
             sb.append("-ext ");
-
-            if (null != saname) {
-                sb.append("\"san=");
-                sb.append(saname);
-                sb.append("\" ");
-            }
+            sb.append("\"san=");
+            sb.append(saname);
+            sb.append("\" ");
         }
 
         log("Generating Key for " + alias);

--- a/src/main/org/apache/tools/ant/taskdefs/GenerateKey.java
+++ b/src/main/org/apache/tools/ant/taskdefs/GenerateKey.java
@@ -181,11 +181,13 @@ public class GenerateKey extends Task {
 
     protected String sigalg;
     protected String keyalg;
+    protected String saname;
     protected String dname;
     protected DistinguishedName expandedDname;
     protected int keysize;
     protected int validity;
     protected boolean verbose;
+    private boolean useExtension;
     // CheckStyle:VisibilityModifier ON
 
     /**
@@ -219,6 +221,21 @@ public class GenerateKey extends Task {
                                     + " both as attribute and element.");
         }
         this.dname = dname;
+    }
+
+    /**
+     * The subject alternative name for entity.
+     *
+     * @param saname subject alternative name
+     */
+    public void setSaname(final String saname) {
+        if (JavaEnvUtils.isAtLeastJavaVersion(JavaEnvUtils.JAVA_1_7)) {
+            this.saname = saname;
+            this.useExtension = true;
+        } else {
+            log("The SubjectAlternativeName extension is not available for "
+               +"the Java Version being used.");
+        }
     }
 
     /**
@@ -400,7 +417,6 @@ public class GenerateKey extends Task {
             sb.append("\" ");
         }
 
-
         if (0 < keysize) {
             sb.append("-keysize \"");
             sb.append(keysize);
@@ -413,6 +429,16 @@ public class GenerateKey extends Task {
             sb.append("\" ");
         }
 
+        if (useExtension) {
+            sb.append("-ext ");
+
+            if (null != saname) {
+                sb.append("\"san=");
+                sb.append(saname);
+                sb.append("\" ");
+            }
+        }
+
         log("Generating Key for " + alias);
         final ExecTask cmd = new ExecTask(this);
         cmd.setExecutable(JavaEnvUtils.getJdkExecutable("keytool"));
@@ -423,4 +449,3 @@ public class GenerateKey extends Task {
         cmd.execute();
     }
 }
-


### PR DESCRIPTION
Beginning with Java 7, keytool supports the SubjectAlternativeName extension on X.509 certificates.
[Java 7 Keytool Documentation](https://docs.oracle.com/javase/7/docs/technotes/tools/windows/keytool.html)

This enhancement will be useful to users who use Ant to issue certificates for their project. Especially, for example, if the project is a web application that is expected to be accessed through modern browsers who are beginning to drop support for Common Name.
[Chrome 58 Deprecations - Remove support for commonName matching in certificates](https://developers.google.com/web/updates/2017/03/chrome-58-deprecations#remove_support_for_commonname_matching_in_certificates)

Targeting 1.9.x branch now, this can be merged into master too.