### PR TITLE
bz-62655 throw a BuildException from augment task 

### DIFF
--- a/src/main/org/apache/tools/ant/taskdefs/AugmentReference.java
+++ b/src/main/org/apache/tools/ant/taskdefs/AugmentReference.java
@@ -17,6 +17,7 @@
  */
 package org.apache.tools.ant.taskdefs;
 
+import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.RuntimeConfigurable;
 import org.apache.tools.ant.Task;
@@ -48,7 +49,7 @@ public class AugmentReference extends Task implements TypeAdapter {
             log("project reference " + id + "=" + String.valueOf(result), Project.MSG_DEBUG);
             return result;
         }
-        throw new IllegalStateException("Unknown reference \"" + id + "\"");
+        throw new BuildException("Unknown reference \"" + id + "\"");
     }
 
     /**
@@ -63,7 +64,7 @@ public class AugmentReference extends Task implements TypeAdapter {
             RuntimeConfigurable wrapper = getWrapper();
             id = wrapper.getId();
             if (id == null) {
-                throw new IllegalStateException(getTaskName() + " attribute 'id' unset");
+                throw new BuildException(getTaskName() + " attribute 'id' unset");
             }
             wrapper.setAttribute("id", null);
             wrapper.removeAttribute("id");


### PR DESCRIPTION
Reference https://bz.apache.org/bugzilla/show_bug.cgi?id=62655

The manual of the augment task[1] states that it's supposed to throw a `BuildException` if the referenced id value isn't known. I admit that the bugzilla is more about the id attribute not being specified whereas the manual seems to talk about the value of id being unknown reference, but I think the issue itself can be considered valid.

The referenced bugzilla issue shows that it throws an `IllegalStateException`. That exception then does indeed get thrown as a BuildException[2] but the `reason` that gets reported to the build listeners[3] is the original cause (in this case the `IllegalStateException`).

The commit here is trivial and it throws the `BuildException` from the `augment` task when either `id` isn't specified or it points to an unknown reference. However, given that it appears that this task has always been in this manner, I wanted to make sure there isn't any specific reason of its current implementation.

There's already tests for this task which pass both with and without this change[4]


[1] https://ant.apache.org/manual/Tasks/augment.html
[2] https://github.com/apache/ant/blob/1.9.x/src/main/org/apache/tools/ant/Task.java#L360
[3] https://github.com/apache/ant/blob/1.9.x/src/main/org/apache/tools/ant/Task.java#L368
[4] https://github.com/apache/ant/blob/1.9.x/src/tests/antunit/taskdefs/augment-test.xml