### PR TITLE
Avoid FileInputStream and FileOutputStream.

### DIFF
--- a/src/tests/antunit/core/uuencode/src/task/BaseTask.java
+++ b/src/tests/antunit/core/uuencode/src/task/BaseTask.java
@@ -26,6 +26,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 
 /**
  * Base class for the uuencode/decode test tasks.
@@ -54,8 +55,8 @@ abstract public class BaseTask extends Task {
         OutputStream outputStream = null;
         try {
             inputStream = new BufferedInputStream(
-                new FileInputStream(getInFile()));
-            outputStream = new FileOutputStream(getOutFile());
+                Files.newInputStream(getInFile().toPath()));
+            outputStream = Files.newOutputStream(getOutFile().toPath());
             doit(inputStream, outputStream);
         } catch (Exception ex) {
             throw new BuildException(ex);

--- a/src/tests/junit/org/apache/tools/ant/taskdefs/BZip2Test.java
+++ b/src/tests/junit/org/apache/tools/ant/taskdefs/BZip2Test.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 
 import static org.hamcrest.Matchers.endsWith;
 import static org.junit.Assert.assertEquals;
@@ -68,12 +69,12 @@ public class BZip2Test {
         File actualFile   = new File(outputDir, "asf-logo-huge.tar.bz2");
 
         InputStream originalIn =
-            new BufferedInputStream(new FileInputStream(originalFile));
+            new BufferedInputStream(Files.newInputStream(originalFile.toPath()));
         assertEquals((byte) 'B', originalIn.read());
         assertEquals((byte) 'Z', originalIn.read());
 
         InputStream actualIn =
-            new BufferedInputStream(new FileInputStream(actualFile));
+            new BufferedInputStream(Files.newInputStream(actualFile.toPath()));
         assertEquals((byte) 'B', actualIn.read());
         assertEquals((byte) 'Z', actualIn.read());
 

--- a/src/tests/junit/org/apache/tools/ant/taskdefs/FixCrLfTest.java
+++ b/src/tests/junit/org/apache/tools/ant/taskdefs/FixCrLfTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 
 import junit.framework.AssertionFailedError;
 
@@ -234,8 +235,8 @@ public class FixCrLfTest {
     public void assertEqualContent(File expect, File result) throws AssertionFailedError, IOException {
         assertTrue("Expected file " + result + " doesn\'t exist", result.exists());
 
-        try (InputStream inExpect = new BufferedInputStream(new FileInputStream(expect));
-             InputStream inResult = new BufferedInputStream(new FileInputStream(result))) {
+        try (InputStream inExpect = new BufferedInputStream(Files.newInputStream(expect.toPath()));
+             InputStream inResult = new BufferedInputStream(Files.newInputStream(result.toPath()))) {
 
             int expectedByte = inExpect.read();
             while (expectedByte != -1) {

--- a/src/tests/junit/org/apache/tools/ant/taskdefs/ReplaceTest.java
+++ b/src/tests/junit/org/apache/tools/ant/taskdefs/ReplaceTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.BuildFileRule;
@@ -144,8 +145,8 @@ public class ReplaceTest {
     public void assertEqualContent(File expect, File result) throws IOException {
         assertTrue("Expected file " + result + " doesn't exist", result.exists());
 
-        try (InputStream inExpect = new BufferedInputStream(new FileInputStream(expect));
-             InputStream inResult = new BufferedInputStream(new FileInputStream(result))) {
+        try (InputStream inExpect = new BufferedInputStream(Files.newInputStream(expect.toPath()));
+             InputStream inResult = new BufferedInputStream(Files.newInputStream(result.toPath()))) {
             int expectedByte = inExpect.read();
             while (expectedByte != -1) {
                 assertEquals(expectedByte, inResult.read());


### PR DESCRIPTION
Avoid FileInputStream and FileOutputStream. These classes override the finalize method. As a result, their objects are only cleaned when the garbage collector performs a sweep. Since Java 7, programmers can use Files.newInputStream and Files.newOutputStream instead of FileInputStream and FileOutputStream to improve performance as recommended in this Java JDK bug-report.