### PR TITLE
Use valid markup

### DIFF
--- a/manual/Tasks/junitlauncher.html
+++ b/manual/Tasks/junitlauncher.html
@@ -175,7 +175,7 @@
 <p>
     Below is an example of setting up the classpath to include the Jupiter test engine and
     the JUnit platform libraries during the execution of the tests.
-    <br/>
+</p>
     <pre>
 &lt;project&gt;
 
@@ -228,8 +228,9 @@
     &lt;/target&gt;
 &lt;/project&gt;
     </pre>
-
+<p>
     In the example above,
+</p>
     <ul>
         <li>The <code>src/lib/jupiter</code> directory is expected to contain
         the Jupiter test engine related jars (which have been
@@ -240,6 +241,7 @@
         <a href="#junit-platform-libraries">listed in an earlier section of this
         document</a>)</li>
     </ul>
+<p>
     In the <code>test</code> target we use the <code>classpath</code> nested element
     to point to the <code>junit.engine.jupiter.classpath</code> and <code>junit.platform.libs.classpath</code>
     containing those jars.
@@ -602,13 +604,13 @@ The <code>fork</code> element allows the following nested elements:
 <p>
     Additional JVM arguments may be passed to the forked JVM via the <code>jvmarg</code> elements.
     For example:
+</p>
     <pre>
     &lt;fork ...&gt;
       &lt;jvmarg value="-Djava.compiler=NONE"/&gt;
       ...
     &lt;/fork&gt;
     </pre>
-</p>
 
 <p>
     <code>jvmarg</code> allows all attributes described in <a href="../using.html#arg">Command-line Arguments</a>
@@ -617,13 +619,13 @@ The <code>fork</code> element allows the following nested elements:
 <h5>sysproperty</h5>
 <p>
     The <code>sysproperty</code> elements allow passing Java system properties to the forked JVM:
+</p>
     <pre>
     &lt;fork&gt;
         &lt;sysproperty key="greeting" value="hello world"/&gt;
     ...
     &lt;/fork&gt;
     </pre>
-</p>
 <p>
     The attributes for this element are the same as for <a href="../Tasks/exec.html#env">environment variables</a>
 </p>

--- a/manual/Tasks/link.html
+++ b/manual/Tasks/link.html
@@ -279,7 +279,7 @@ which executes a particular module's main class.  Attributes:</p>
 
 <h4 id="nested-locale">locale</h4>
 <p>Specifies locales to include in linked image.  May be specified multiple
-times.  Requires <code>jdk.localedata</code> module.  Attributes:
+times.  Requires <code>jdk.localedata</code> module.  Attributes:</p>
 <table class="attr">
   <tr>
     <th scope="col">Attribute</th>
@@ -318,7 +318,7 @@ times.  Attributes:</p>
 
 <p>If the <code>resourceOrder</code> attribute is also present on the task, its
 patterns are treated as if they occur before patterns in nested
-<code><resourceOrder></code> elements.</p>
+<code>&lt;resourceOrder&gt;</code> elements.</p>
 
 <h4 id="nested-excludeResources">excludeResources</h4>
 <p>Excludes files from linked image tree.  May be specified multiple times.
@@ -423,7 +423,7 @@ patterns are treated as if they occur before patterns in nested
 
 <h4 id="nested-releaseInfo">releaseInfo</h4>
 <p>Replaces, augments, or trims the image's release info properties.
-Can be specified multiple times.  Attributes:
+Can be specified multiple times.  Attributes:</p>
 <table class="attr">
   <tr>
     <th scope="col">Attribute</th>
@@ -575,7 +575,6 @@ jmod describe "$FOREIGN_JDK_HOME"/jmods/java.base.jmod | grep '^platform'
 </pre>
 </li>
 </ul>
-<ul>
 
 </body>
 </html>


### PR DESCRIPTION
For 100% compliance, all HTML documents in the manual should add `<!DOCTYPE html>` and replace `<meta http-equiv="Content-Language" content="en-us">` with `<html lang="en-us">`