### PR TITLE
Wrap FileWriter with BufferedWriter for better performance

### DIFF
--- a/src/main/org/apache/tools/ant/taskdefs/optional/ssh/SSHExec.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/ssh/SSHExec.java
@@ -18,6 +18,7 @@
 
 package org.apache.tools.ant.taskdefs.optional.ssh;
 
+import java.io.BufferedWriter;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -481,7 +482,7 @@ public class SSHExec extends SSHBase {
      */
     private void writeToFile(final String from, final boolean append, final File to)
         throws IOException {
-        try (FileWriter out = new FileWriter(to.getAbsolutePath(), append)) {
+        try (BufferedWriter out = new BufferedWriter(new FileWriter(to.getAbsolutePath(), append))) {
             final StringReader in = new StringReader(from);
             final char[] buffer = new char[BUFFER_SIZE];
             while (true) {


### PR DESCRIPTION
When the FileWriter.write() method is invoked in a loop, it has a bad impact on the performance of program. Therefore, the BufferedWriter is recommended to improve performance as it can reduce IO operations, especially used in a loop.