### PR TITLE
Refer to Java 8 documentation for consistency

### DIFF
--- a/src/main/org/apache/tools/ant/taskdefs/Jar.java
+++ b/src/main/org/apache/tools/ant/taskdefs/Jar.java
@@ -573,7 +573,7 @@ public class Jar extends Zip {
     /**
      * Create the index list to speed up classloading.
      * This is a JDK 1.3+ specific feature and is enabled by default. See
-     * <a href="https://docs.oracle.com/javase/1.5.0/docs/guide/jar/jar.html#JAR%20Index">
+     * <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#JAR_Index">
      * the JAR index specification</a> for more details.
      *
      * @param zOut the zip stream representing the jar being built.

--- a/src/main/org/apache/tools/ant/taskdefs/SignJar.java
+++ b/src/main/org/apache/tools/ant/taskdefs/SignJar.java
@@ -40,10 +40,9 @@ import org.apache.tools.ant.util.ResourceUtils;
  * exists then its modification date is used as a cue as to whether to resign
  * any JAR file.
  *
- * Timestamp driven signing is based on the unstable and inadequately documented
- * information in the Java1.5 docs
- * @see <a href="https://docs.oracle.com/javase/1.5.0/docs/guide/security/time-of-signing-beta1.html">
- * beta documentation</a>
+ * Timestamp signature support is based on Java 8
+ * @see <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/time-of-signing.html">
+ * documentation</a>
  * @ant.task category="java"
  * @since Ant 1.1
  */

--- a/src/main/org/apache/tools/ant/types/PatternSet.java
+++ b/src/main/org/apache/tools/ant/types/PatternSet.java
@@ -194,8 +194,8 @@ public class PatternSet extends DataType implements Cloneable {
          *
          * <p>
          * For a list of possible values see
-         * <a href="https://docs.oracle.com/javase/1.5.0/docs/guide/intl/encoding.doc.html">
-         * https://docs.oracle.com/javase/1.5.0/docs/guide/intl/encoding.doc.html</a>.
+         * <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html">
+         * https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html</a>.
          * </p>
          *
          * @param encoding String

--- a/src/main/org/apache/tools/zip/ZipFile.java
+++ b/src/main/org/apache/tools/zip/ZipFile.java
@@ -103,7 +103,8 @@ public class ZipFile implements Closeable {
      * The encoding to use for filenames and the file comment.
      *
      * <p>For a list of possible values see <a
-     * href="https://docs.oracle.com/javase/1.5.0/docs/guide/intl/encoding.doc.html">https://docs.oracle.com/javase/1.5.0/docs/guide/intl/encoding.doc.html</a>.
+     * href="https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html">
+     * https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html</a>.
      * Defaults to the platform's default character encoding.</p>
      */
     private final String encoding;

--- a/src/main/org/apache/tools/zip/ZipOutputStream.java
+++ b/src/main/org/apache/tools/zip/ZipOutputStream.java
@@ -253,7 +253,8 @@ public class ZipOutputStream extends FilterOutputStream {
      * The encoding to use for filenames and the file comment.
      *
      * <p>For a list of possible values see <a
-     * href="https://docs.oracle.com/javase/1.5.0/docs/guide/intl/encoding.doc.html">https://docs.oracle.com/javase/1.5.0/docs/guide/intl/encoding.doc.html</a>.
+     * href="https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html">
+     * https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html</a>.
      * Defaults to the platform's default character encoding.</p>
      *
      * @since 1.3
@@ -379,7 +380,8 @@ public class ZipOutputStream extends FilterOutputStream {
      * The encoding to use for filenames and the file comment.
      *
      * <p>For a list of possible values see <a
-     * href="https://docs.oracle.com/javase/1.5.0/docs/guide/intl/encoding.doc.html">https://docs.oracle.com/javase/1.5.0/docs/guide/intl/encoding.doc.html</a>.
+     * href="https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html">
+     * https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html</a>.
      * Defaults to the platform's default character encoding.</p>
      * @param encoding the encoding value
      * @since 1.3


### PR DESCRIPTION
http to https changes in references also introduced Java 5 to 8 changes, so let's be consistent