### PR TITLE
Send FQDN instead of simple hostname in SMTP HELO command

### DIFF
--- a/src/main/org/apache/tools/mail/MailMessage.java
+++ b/src/main/org/apache/tools/mail/MailMessage.java
@@ -393,7 +393,7 @@ public class MailMessage {
     }
 
     void sendHelo() throws IOException {
-        String local = InetAddress.getLocalHost().getHostName();
+        String local = InetAddress.getLocalHost().getCanonicalHostName();
         int[] ok = {OK_HELO};
         send("HELO " + local, ok);
     }

--- a/src/tests/junit/org/apache/tools/mail/MailMessageTest.java
+++ b/src/tests/junit/org/apache/tools/mail/MailMessageTest.java
@@ -44,7 +44,7 @@ public class MailMessageTest {
     @Before
     public void setUp() {
         try {
-            local = InetAddress.getLocalHost().getHostName();
+            local = InetAddress.getLocalHost().getCanonicalHostName();
         } catch (java.net.UnknownHostException uhe) {
             // ignore
         }


### PR DESCRIPTION
Some SMTP servers block messages when HELO command contains a simple hostname instead of a fully qualified domain name.

This path fixes this by using getCanonicalHostName instead of getHostName
See https://github.com/apache/ant/pull/100