### PR TITLE
Made some variable names more consistent with the other parts.

### DIFF
--- a/src/main/org/apache/tools/ant/BuildException.java
+++ b/src/main/org/apache/tools/ant/BuildException.java
@@ -74,15 +74,15 @@ public class BuildException extends RuntimeException {
      * Constructs an exception with the given message and exception as
      * a root cause and a location in a file.
      *
-     * @param msg A description of or information about the exception.
-     *            Should not be <code>null</code> unless a cause is specified.
+     * @param message A description of or information about the exception.
+     *                Should not be <code>null</code> unless a cause is specified.
      * @param cause The exception that might have caused this one.
      *              May be <code>null</code>.
      * @param location The location in the project file where the error
      *                 occurred. Must not be <code>null</code>.
      */
-    public BuildException(String msg, Throwable cause, Location location) {
-        this(msg, cause);
+    public BuildException(String message, Throwable cause, Location location) {
+        this(message, cause);
         this.location = location;
     }
 

--- a/src/main/org/apache/tools/ant/taskdefs/Checksum.java
+++ b/src/main/org/apache/tools/ant/taskdefs/Checksum.java
@@ -262,12 +262,12 @@ public class Checksum extends MatchingTask implements Condition {
      * Specify the pattern to use as a MessageFormat pattern.
      *
      * <p>{0} gets replaced by the checksum, {1} by the filename.</p>
-     * @param p a <code>String</code> value
+     * @param pattern a <code>String</code> value
      *
      * @since 1.7.0
      */
-    public void setPattern(String p) {
-        format = new MessageFormat(p);
+    public void setPattern(String pattern) {
+        format = new MessageFormat(pattern);
     }
 
     /**

--- a/src/main/org/apache/tools/ant/taskdefs/condition/Equals.java
+++ b/src/main/org/apache/tools/ant/taskdefs/condition/Equals.java
@@ -50,10 +50,10 @@ public class Equals implements Condition {
     /**
      * Set the first string
      *
-     * @param a1 the first string
+     * @param arg1 the first string
      */
-    public void setArg1(String a1) {
-        setArg1Internal(a1);
+    public void setArg1(String arg1) {
+        setArg1Internal(arg1);
     }
 
     private void setArg1Internal(Object arg1) {
@@ -77,10 +77,10 @@ public class Equals implements Condition {
     /**
      * Set the second string
      *
-     * @param a2 the second string
+     * @param arg2 the second string
      */
-    public void setArg2(String a2) {
-        setArg2Internal(a2);
+    public void setArg2(String arg2) {
+        setArg2Internal(arg2);
     }
 
     private void setArg2Internal(Object arg2) {

--- a/src/main/org/apache/tools/ant/taskdefs/cvslib/RCSFile.java
+++ b/src/main/org/apache/tools/ant/taskdefs/cvslib/RCSFile.java
@@ -26,8 +26,8 @@ class RCSFile {
     private String revision;
     private String previousRevision;
 
-    RCSFile(final String name, final String rev) {
-        this(name, rev, null);
+    RCSFile(final String name, final String revision) {
+        this(name, revision, null);
     }
 
     RCSFile(final String name,

--- a/src/main/org/apache/tools/ant/taskdefs/optional/junit/JUnitTestRunner.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/junit/JUnitTestRunner.java
@@ -713,15 +713,15 @@ public class JUnitTestRunner implements TestListener, JUnitTaskMirror.JUnitTestR
         logTestListenerEvent("endTest(" + testName + ")");
     }
 
-    private void logTestListenerEvent(String msg) {
+    private void logTestListenerEvent(String message) {
         if (logTestListenerEvents) {
             @SuppressWarnings("resource")
             final PrintStream out = savedOut != null ? savedOut : System.out;
             out.flush();
-            final StringTokenizer msgLines =
-                new StringTokenizer(String.valueOf(msg), "\r\n", false);
-            while (msgLines.hasMoreTokens()) {
-                out.println(JUnitTask.TESTLISTENER_PREFIX + msgLines.nextToken());
+            final StringTokenizer messageLines =
+                new StringTokenizer(String.valueOf(message), "\r\n", false);
+            while (messageLines.hasMoreTokens()) {
+                out.println(JUnitTask.TESTLISTENER_PREFIX + messageLines.nextToken());
             }
             out.flush();
         }
@@ -1241,9 +1241,9 @@ public class JUnitTestRunner implements TestListener, JUnitTaskMirror.JUnitTestR
                     // JUnit 4-specific test GUIs will show just "failures".
                     // But Ant's output shows "failures" vs. "errors".
                     // We would prefer to show "failure" for things that logically are.
-                    final String msg = t.getMessage();
-                    final AssertionFailedError failure = msg != null
-                        ? new AssertionFailedError(msg) : new AssertionFailedError();
+                    final String message = t.getMessage();
+                    final AssertionFailedError failure = message != null
+                        ? new AssertionFailedError(message) : new AssertionFailedError();
                     failure.initCause(t.getCause());
                     failure.setStackTrace(t.getStackTrace());
                     testListener.addFailure(test, failure);

--- a/src/main/org/apache/tools/ant/types/Commandline.java
+++ b/src/main/org/apache/tools/ant/types/Commandline.java
@@ -360,8 +360,8 @@ public class Commandline implements Cloneable {
      * @param line an array of arguments to append.
      */
     public void addArguments(String[] line) {
-        for (String l : line) {
-            createArgument().setValue(l);
+        for (String argument : line) {
+            createArgument().setValue(argument);
         }
     }
 
@@ -464,11 +464,11 @@ public class Commandline implements Cloneable {
         }
         // path containing one or more elements
         final StringBuilder result = new StringBuilder();
-        for (String l : line) {
+        for (String argument : line) {
             if (result.length() > 0) {
                 result.append(' ');
             }
-            result.append(quoteArgument(l));
+            result.append(quoteArgument(argument));
         }
         return result.toString();
     }


### PR DESCRIPTION
Hello, we're developing an automated system that detects inconsistent variable names in a large software project. Our system checks if each variable name is consistent with the other variables in its usage, and proposes correct candidates if inconsistency is found. This is a part of academic research that we hope to publish soon, but as a part of the evaluation, we applied our systems to your projects and got a few interesting results. We carefully reviewed our system output and manually created a patch to correct a few variable names. We would be delighted if this patch is found to be useful. If you have a question or suggestion regarding this patch, we'd happily answer. Thank you.

P.S. our patch is purely for readability purposes and does not change any functionality. A couple of issues that we've noticed were left untouched. For example, there are some overlap use between "msgLevel" "logLevel" and "priority" for logging, but we weren't sure whether they actually refer to the same concept or not, so we didn't change them.