### PR TITLE
Correct a typo

### DIFF
--- a/manual/Tasks/mkdir.html
+++ b/manual/Tasks/mkdir.html
@@ -27,7 +27,7 @@
 <h2 id="mkdir">Mkdir</h2>
 <h3>Description</h3>
 <p>Creates a directory. Also non-existent parent directories are created, when necessary. Does
-nothing if the directory already exist.</p>
+nothing if the directory already exists.</p>
 <h3>Parameters</h3>
 <table class="attr">
   <tr>


### PR DESCRIPTION
Correct "Does nothing if the directory already exist." to "Does nothing if the directory already **exists**."