### PR TITLE
Support SSH config file in the ssh tasks

### DIFF
--- a/WHATSNEW
+++ b/WHATSNEW
@@ -14,6 +14,10 @@ Fixed bugs:
    files.
    Bugzilla Report 63874
 
+ * sshexec, sshsession and scp now support a new sshConfig parameter.
+   It specifies the SSH configuration file (typically ${user.home}/.ssh/config)
+   defining the username and keyfile to be used per host.
+
 Other changes:
 --------------
 

--- a/manual/Tasks/scp.html
+++ b/manual/Tasks/scp.html
@@ -143,6 +143,14 @@ information.  This task has been tested with <code>jsch-0.1.2</code> and later.<
     <td>No; defaults to an empty string</td>
   </tr>
   <tr>
+    <td>sshConfig</td>
+    <td>Location of the file holding the OpenSSH style configuration (e.g. <code>${user.home}/.ssh/config</code>).
+        The username and the key file are read from the configuration file,
+        unless they are already specified in the task parameters.
+        <em>since Ant 1.10.8</em></td>
+    <td>No</td>
+  </tr>
+  <tr>
     <td>verbose</td>
     <td>Determines whether SCP outputs verbosely to the user. Currently this means outputting
       dots/stars showing the progress of a file transfer.  <em>since Ant 1.6.2</em></td>

--- a/manual/Tasks/sshexec.html
+++ b/manual/Tasks/sshexec.html
@@ -105,6 +105,14 @@ JSCh earlier than 0.1.28.</p>
     <td>No; defaults to an empty string</td>
   </tr>
   <tr>
+    <td>sshConfig</td>
+    <td>Location of the file holding the OpenSSH style configuration (e.g. <code>${user.home}/.ssh/config</code>).
+        The username and the key file are read from the configuration file,
+        unless they are already specified in the task parameters.
+        <em>since Ant 1.10.8</em></td>
+    <td>No</td>
+  </tr>
+  <tr>
     <td>suppresssystemout</td>
     <td>Whether to suppress system out. <em>since Ant 1.9.0</em></td>
     <td>No; defaults to <q>false</q></td>

--- a/manual/Tasks/sshsession.html
+++ b/manual/Tasks/sshsession.html
@@ -111,6 +111,14 @@ JSCh earlier than 0.1.28.</p>
     <td>No; defaults to an empty string</td>
   </tr>
   <tr>
+    <td>sshConfig</td>
+    <td>Location of the file holding the OpenSSH style configuration (e.g. <code>${user.home}/.ssh/config</code>).
+        The username and the key file are read from the configuration file,
+        unless they are already specified in the task parameters.
+        <em>since Ant 1.10.8</em></td>
+    <td>No</td>
+  </tr>
+  <tr>
     <td>timeout</td>
     <td>Give up if the connection cannot be established within the specified time (given in
       milliseconds).</td>

--- a/src/main/org/apache/tools/ant/taskdefs/optional/ssh/SSHBase.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/ssh/SSHBase.java
@@ -264,7 +264,7 @@ public abstract class SSHBase extends Task implements LogListener {
      * @throws BuildException on error
      */
     protected void loadSshConfig() throws BuildException {
-        if (sshConfig != null) {
+        if (sshConfig != null && (userInfo.getName() == null || userInfo.getKeyfile() == null)) {
             if (!new File(sshConfig).exists()) {
                 throw new BuildException("The SSH configuration file specified doesn't exist: " + sshConfig);
             }

--- a/src/main/org/apache/tools/ant/taskdefs/optional/ssh/SSHExec.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/ssh/SSHExec.java
@@ -284,6 +284,9 @@ public class SSHExec extends SSHBase {
         if (getHost() == null) {
             throw new BuildException("Host is required.");
         }
+        
+        loadSshConfig();
+        
         if (getUserInfo().getName() == null) {
             throw new BuildException("Username is required.");
         }

--- a/src/main/org/apache/tools/ant/taskdefs/optional/ssh/SSHSession.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/ssh/SSHSession.java
@@ -132,6 +132,9 @@ public class SSHSession extends SSHBase {
         if (getHost() == null) {
             throw new BuildException("Host is required.");
         }
+        
+        loadSshConfig();
+        
         if (getUserInfo().getName() == null) {
             throw new BuildException("Username is required.");
         }

--- a/src/main/org/apache/tools/ant/taskdefs/optional/ssh/Scp.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/ssh/Scp.java
@@ -435,19 +435,22 @@ public class Scp extends SSHBase {
             throw new BuildException("no username was given.  Can't authenticate.");
         }
 
-        if (getUserInfo().getPassword() == null
-            && getUserInfo().getKeyfile() == null) {
-            throw new BuildException(
-                "neither password nor keyfile for user %s has been given.  Can't authenticate.",
-                getUserInfo().getName());
-        }
-
         final int indexOfPath = uri.indexOf(':', indexOfAt + 1);
         if (indexOfPath == -1) {
             throw new BuildException("no remote path in %s", uri);
         }
 
         setHost(uri.substring(indexOfAt + 1, indexOfPath));
+        
+        loadSshConfig();
+        
+        if (getUserInfo().getPassword() == null
+            && getUserInfo().getKeyfile() == null) {
+            throw new BuildException(
+                "neither password nor keyfile for user %s has been given.  Can't authenticate.",
+                getUserInfo().getName());
+        }
+        
         String remotePath = uri.substring(indexOfPath + 1);
         if (remotePath.isEmpty()) {
             remotePath = ".";


### PR DESCRIPTION
Here is a PR improving the sshexec, sshsession and scp tasks to support the SSH config file (typically ~/.ssh/config). This file defines the username and key file to be used per host. If Ant could support it that would avoid duplicating the key information from the SSH config in the Ant builds.

Ivy already supports it for its SSH resolver: https://ant.apache.org/ivy/history/latest-milestone/resolver/ssh.html