### PR TITLE
junitlaucher legacy-xml: don't loose exception from @BeforeAll

### DIFF
--- a/contributors.xml
+++ b/contributors.xml
@@ -1033,6 +1033,10 @@
     <last>Sahu</last>
   </name>
   <name>
+    <first>Marc</first>
+    <last>Guillemot</last>
+  </name>
+  <name>
     <first>Marcel</first>
     <last>Schutte</last>
   </name>

--- a/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/LegacyXmlResultFormatter.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/LegacyXmlResultFormatter.java
@@ -232,12 +232,18 @@ class LegacyXmlResultFormatter extends AbstractJUnitResultFormatter implements T
         void writeTestCase(final XMLStreamWriter writer) throws XMLStreamException {
             for (final Map.Entry<TestIdentifier, Stats> entry : testIds.entrySet()) {
                 final TestIdentifier testId = entry.getKey();
-                if (!testId.isTest()) {
-                    // only interested in test methods
+                if (!testId.isTest() && !failed.containsKey(testId)) {
+                    // only interested in test methods unless there was a failure
                     continue;
                 }
-                // find the parent class of this test method
-                final Optional<ClassSource> parentClassSource = findFirstParentClassSource(testId);
+                // find the associated class of this test
+                final Optional<ClassSource> parentClassSource;
+                if (testId.isTest()) {
+                    parentClassSource = findFirstParentClassSource(testId);
+                }
+                else {
+                    parentClassSource = findFirstClassSource(testId);
+                }
                 if (!parentClassSource.isPresent()) {
                     continue;
                 }

--- a/src/tests/junit/org/apache/tools/ant/taskdefs/optional/junitlauncher/JUnitLauncherTaskTest.java
+++ b/src/tests/junit/org/apache/tools/ant/taskdefs/optional/junitlauncher/JUnitLauncherTaskTest.java
@@ -24,6 +24,8 @@ import static org.example.junitlauncher.Tracker.verifySuccess;
 import static org.example.junitlauncher.Tracker.wasTestRun;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -174,6 +176,18 @@ public class JUnitLauncherTaskTest {
         Assert.assertTrue("JupiterSampleTest#testSkipped was expected to be skipped", verifySkipped(trackerFile,
                 JupiterSampleTest.class.getName(), "testSkipped"));
         Assert.assertFalse("ForkedTest wasn't expected to be run", wasTestRun(trackerFile, ForkedTest.class.getName()));
+
+        verifyLegacyXMLFile("TEST-org.example.junitlauncher.jupiter.JupiterSampleTestFailingBeforeAll.xml", "<failure message=\"Intentional failure\" type=\"java.lang.RuntimeException\">");
+        verifyLegacyXMLFile("TEST-org.example.junitlauncher.jupiter.JupiterSampleTestFailingStatic.xml", "Caused by: java.lang.RuntimeException: Intentional exception from static init block");
+    }
+
+    private void verifyLegacyXMLFile(final String fileName, final String expectedContentExtract) throws IOException {
+        final String outputDir = buildRule.getProject().getProperty("output.dir");
+        final Path xmlFile = Paths.get(outputDir, fileName);
+
+        Assert.assertTrue("XML file doesn't exist: " + xmlFile, Files.exists(xmlFile));
+        final String content = new String(Files.readAllBytes(xmlFile), StandardCharsets.UTF_8);
+        Assert.assertTrue(fileName + " doesn't contain " + expectedContentExtract, content.contains(expectedContentExtract));
     }
 
     /**

--- a/src/tests/junit/org/example/junitlauncher/jupiter/JupiterSampleTestFailingStatic.java
+++ b/src/tests/junit/org/example/junitlauncher/jupiter/JupiterSampleTestFailingStatic.java
@@ -1,0 +1,39 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.example.junitlauncher.jupiter;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ *
+ */
+public class JupiterSampleTestFailingStatic {
+
+    static {
+        if (true) {
+            throw new RuntimeException("Intentional exception from static init block");
+        }
+    }
+
+
+    @Test
+    void testSucceeds() {
+        System.out.println("hello");
+    }
+
+}


### PR DESCRIPTION
Reports exception occuring in a @BeforeAll method in the TEST-xxx.xml file. Currently the exception is not reported making users blind.