### PR TITLE
Puppy Crawl no longer hosts Checkstyle DTD

### DIFF
--- a/src/etc/checkstyle/checkstyle-config
+++ b/src/etc/checkstyle/checkstyle-config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "http://www.checkstyle.org/dtds/configuration_1_3.dtd">
 <!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
(since March 2019, actually…)