### PR TITLE
use displayName instead of legacyReportingName in xml reports

### DIFF
--- a/fetch.xml
+++ b/fetch.xml
@@ -242,6 +242,7 @@ Set -Ddest=LOCATION on the command line
           description="load junit jupiter engine libraries (necessary only for internal Ant project tests)"
           depends="init">
     <f2 project="org.junit.jupiter" archive="junit-jupiter-engine" />
+    <f2 project="org.junit.jupiter" archive="junit-jupiter-params" />
   </target>
 
   <target name="junit-engine-vintage"

--- a/lib/libraries.properties
+++ b/lib/libraries.properties
@@ -60,6 +60,7 @@ junit-platform-launcher.version=1.2.0
 junit-vintage-engine.version=5.2.0
 # Only used for internal tests in Ant project
 junit-jupiter-engine.version=5.2.0
+junit-jupiter-params.version=5.2.0
 jsch.version=0.1.55
 jython.version=2.7.0
 # log4j 1.2.15 requires JMS and a few other Sun jars that are not in the m2 repo

--- a/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/LegacyXmlResultFormatter.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/LegacyXmlResultFormatter.java
@@ -252,7 +252,7 @@ class LegacyXmlResultFormatter extends AbstractJUnitResultFormatter implements T
                 final String classname = (parentClassSource.get()).getClassName();
                 writer.writeStartElement(ELEM_TESTCASE);
                 writer.writeAttribute(ATTR_CLASSNAME, classname);
-                writer.writeAttribute(ATTR_NAME, testId.getLegacyReportingName());
+                writer.writeAttribute(ATTR_NAME, testId.getDisplayName());
                 final Stats stats = entry.getValue();
                 writer.writeAttribute(ATTR_TIME, String.valueOf((stats.endedAt - stats.startedAt) / ONE_SECOND));
                 // skipped element if the test was skipped

--- a/src/tests/junit/org/apache/tools/ant/taskdefs/optional/junitlauncher/JUnitLauncherTaskTest.java
+++ b/src/tests/junit/org/apache/tools/ant/taskdefs/optional/junitlauncher/JUnitLauncherTaskTest.java
@@ -179,6 +179,7 @@ public class JUnitLauncherTaskTest {
 
         verifyLegacyXMLFile("TEST-org.example.junitlauncher.jupiter.JupiterSampleTestFailingBeforeAll.xml", "<failure message=\"Intentional failure\" type=\"java.lang.RuntimeException\">");
         verifyLegacyXMLFile("TEST-org.example.junitlauncher.jupiter.JupiterSampleTestFailingStatic.xml", "Caused by: java.lang.RuntimeException: Intentional exception from static init block");
+        verifyLegacyXMLFile("TEST-org.example.junitlauncher.jupiter.JupiterParameterizedSampleTest.xml", "name=\"1: fib(0) = 0\"");
     }
 
     private void verifyLegacyXMLFile(final String fileName, final String expectedContentExtract) throws IOException {

--- a/src/tests/junit/org/example/junitlauncher/jupiter/JupiterParameterizedSampleTest.java
+++ b/src/tests/junit/org/example/junitlauncher/jupiter/JupiterParameterizedSampleTest.java
@@ -1,0 +1,47 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.example.junitlauncher.jupiter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * 
+ */
+class JupiterParameterizedSampleTest {
+
+	@ParameterizedTest(name = "{index}: fib({0}) = {1}")
+	@CsvSource({"0, 0", "1, 1", "2, 1", "3, 2", "4, 3", "5, 5", "6, 8"})
+	void fibonacci(final int input, final int expected) {
+		assertEquals(expected, compute(input));
+	}
+
+    static int compute(int n) {
+    	int result = 0;
+    	
+        if (n <= 1) { 
+        	result = n; 
+        } else { 
+        	result = compute(n - 1) + compute(n - 2); 
+        }
+        
+        return result;
+    }
+}


### PR DESCRIPTION
Allows to have the configured informative test names in the reports instead of the test method signature (like `1: fib(0) = 0`, ..., `7: fib(6) = 8` instead of `fibonacci(int, int)[1]`, ..., `fibonacci(int, int)[7]`.

See discussion in code : https://github.com/apache/ant/commit/5981e1bff1e095bf85ee4d6565bc0c7ff93f2bb6#diff-f985f89ce4779eff2cdcf164d09d5396R246

I was not able to run successfully all tests locally as desired. With some hacks I was able to run `JUnitLauncherTaskTest` with `ant junit-single-test -Djunit.testcase=org.apache.tools.ant.taskdefs.optional.junitlauncher.JUnitLauncherTaskTest` to prepare this patch but can't be sure that the changes don't break something else.