### PR TITLE
Bugfix/catch dynamic test before each

### DIFF
--- a/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/LegacyXmlResultFormatter.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/LegacyXmlResultFormatter.java
@@ -263,13 +263,13 @@ class LegacyXmlResultFormatter extends AbstractJUnitResultFormatter implements T
             }
             
             if (!parentClassSource.isPresent()) {
-            	parentClassSource = findFirstParentClassSource(testId);
+                parentClassSource = findFirstParentClassSource(testId);
             }
             
             return parentClassSource.map(ClassSource::getClassName).orElse(testId.getUniqueId());
-		}
+        }
 
-		private void writeSkipped(final XMLStreamWriter writer, final TestIdentifier testIdentifier) throws XMLStreamException {
+        private void writeSkipped(final XMLStreamWriter writer, final TestIdentifier testIdentifier) throws XMLStreamException {
             if (!skipped.containsKey(testIdentifier)) {
                 return;
             }

--- a/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/LegacyXmlResultFormatter.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/LegacyXmlResultFormatter.java
@@ -238,18 +238,7 @@ class LegacyXmlResultFormatter extends AbstractJUnitResultFormatter implements T
                     // (https://bz.apache.org/bugzilla/show_bug.cgi?id=63850)
                     continue;
                 }
-                // find the associated class of this test
-                final Optional<ClassSource> parentClassSource;
-                if (testId.isTest()) {
-                    parentClassSource = findFirstParentClassSource(testId);
-                }
-                else {
-                    parentClassSource = findFirstClassSource(testId);
-                }
-                if (!parentClassSource.isPresent()) {
-                    continue;
-                }
-                final String classname = (parentClassSource.get()).getClassName();
+                final String classname = findClassnameOrId(testId);
                 writer.writeStartElement(ELEM_TESTCASE);
                 writer.writeAttribute(ATTR_CLASSNAME, classname);
                 writer.writeAttribute(ATTR_NAME, testId.getLegacyReportingName());
@@ -266,7 +255,21 @@ class LegacyXmlResultFormatter extends AbstractJUnitResultFormatter implements T
             }
         }
 
-        private void writeSkipped(final XMLStreamWriter writer, final TestIdentifier testIdentifier) throws XMLStreamException {
+        private String findClassnameOrId(TestIdentifier testId) {
+            // try to find the associated class of this test, if not found use some id to see test in the reports 
+            Optional<ClassSource> parentClassSource = Optional.empty();
+            if (!testId.isTest()) {
+                parentClassSource = findFirstClassSource(testId);
+            }
+            
+            if (!parentClassSource.isPresent()) {
+            	parentClassSource = findFirstParentClassSource(testId);
+            }
+            
+            return parentClassSource.map(ClassSource::getClassName).orElse(testId.getUniqueId());
+		}
+
+		private void writeSkipped(final XMLStreamWriter writer, final TestIdentifier testIdentifier) throws XMLStreamException {
             if (!skipped.containsKey(testIdentifier)) {
                 return;
             }

--- a/src/tests/junit/org/apache/tools/ant/taskdefs/optional/junitlauncher/JUnitLauncherTaskTest.java
+++ b/src/tests/junit/org/apache/tools/ant/taskdefs/optional/junitlauncher/JUnitLauncherTaskTest.java
@@ -179,6 +179,7 @@ public class JUnitLauncherTaskTest {
 
         verifyLegacyXMLFile("TEST-org.example.junitlauncher.jupiter.JupiterSampleTestFailingBeforeAll.xml", "<failure message=\"Intentional failure\" type=\"java.lang.RuntimeException\">");
         verifyLegacyXMLFile("TEST-org.example.junitlauncher.jupiter.JupiterSampleTestFailingStatic.xml", "Caused by: java.lang.RuntimeException: Intentional exception from static init block");
+        verifyLegacyXMLFile("TEST-org.example.junitlauncher.jupiter.JupiterDynamicSampleTestFailingBeforeEach.xml", "<failure message=\"Intentional failure in @BeforeEach\" type=\"java.lang.RuntimeException\">");
     }
 
     private void verifyLegacyXMLFile(final String fileName, final String expectedContentExtract) throws IOException {

--- a/src/tests/junit/org/example/junitlauncher/jupiter/JupiterDynamicSampleTestFailingBeforeEach.java
+++ b/src/tests/junit/org/example/junitlauncher/jupiter/JupiterDynamicSampleTestFailingBeforeEach.java
@@ -1,0 +1,49 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.example.junitlauncher.jupiter;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DynamicContainer;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+/**
+ *
+ */
+class JupiterDynamicSampleTestFailingBeforeEach {
+
+	@BeforeEach
+	void beforeEach() {
+		throw new RuntimeException("Intentional failure in @BeforeEach");
+	}
+
+	@TestFactory
+	Collection<DynamicContainer> dynamicContainers() {
+		DynamicNode t1 = DynamicTest.dynamicTest("the test", () -> {
+		});
+		List<DynamicNode> dynamicTests = Arrays.asList(t1);
+		DynamicContainer c1 = DynamicContainer.dynamicContainer("the dynamic tests", dynamicTests);
+		return Arrays.asList(c1);
+	}
+
+}


### PR DESCRIPTION
Ensure that every failed test is reported by the `LegacyXmlResultFormatter`. Currently failures in `@BeforeEach` with a `@TestFactory` are not visible in the XMLreports. Possibly not fully correct `classname` and `name` attributes are far better than an invisible failure.