### PR TITLE
junit4 Parameterized not reported

### DIFF
--- a/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/LegacyXmlResultFormatter.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/LegacyXmlResultFormatter.java
@@ -386,8 +386,10 @@ class LegacyXmlResultFormatter extends AbstractJUnitResultFormatter implements T
 
         private Optional<ClassSource> findFirstParentClassSource(final TestIdentifier testId) {
             final Optional<TestIdentifier> parent = testPlan.getParent(testId);
-            if (!parent.isPresent() || !parent.get().getSource().isPresent()) {
+            if (!parent.isPresent()) {
                 return Optional.empty();
+            } else if (!parent.get().getSource().isPresent()) {
+                return findFirstParentClassSource(parent.get());
             }
             final TestSource parentSource = parent.get().getSource().get();
             return parentSource instanceof ClassSource ? Optional.of((ClassSource) parentSource)


### PR DESCRIPTION
The LegacyXmlResultsFormatter does not report induvidual testcases for Paramerized tests.
This affects all Junit4 Tests annotated with.

@RunWith(Parameterized.class)

Maybe it would also be better if the code if the code was rewritten that in case no ClassSource was found some other string would be written instead of just silently skipping the testcase.
