### PR TITLE
support to access local properties via propertyset

### DIFF
--- a/src/etc/testcases/taskdefs/optional/echoproperties.xml
+++ b/src/etc/testcases/taskdefs/optional/echoproperties.xml
@@ -129,5 +129,15 @@
     <delete file="test.xml" failonerror="no" />
   </target>
 
+    <target name="testEchoLocalPropertyset">
+        <local name="loc"/>
+        <property name="loc" value="foo"/>
+        <echoproperties>
+            <propertyset>
+                <propertyref name="loc"/>
+            </propertyset>
+        </echoproperties>
+    </target>
+
 </project>
 

--- a/src/main/org/apache/tools/ant/property/LocalPropertyStack.java
+++ b/src/main/org/apache/tools/ant/property/LocalPropertyStack.java
@@ -128,6 +128,7 @@ public class LocalPropertyStack {
         Object currValue = map.get(property);
         if (currValue == NullReturn.NULL) {
             map.put(property, value);
+            return false;
         }
         return true;
     }

--- a/src/tests/junit/org/apache/tools/ant/taskdefs/optional/EchoPropertiesTest.java
+++ b/src/tests/junit/org/apache/tools/ant/taskdefs/optional/EchoPropertiesTest.java
@@ -186,6 +186,12 @@ public class EchoPropertiesTest {
         assertThat(buildRule.getFullLog(), containsString(MagicNames.ANT_VERSION + "="));
     }
 
+    @Test
+    public void testLocalPropertyset() {
+        buildRule.executeTarget("testEchoLocalPropertyset");
+        assertThat(buildRule.getLog(), containsString("loc=foo"));
+    }
+
     private void testEchoPrefixVarious(String target) throws Exception {
         buildRule.executeTarget(target);
         Properties props = loadPropFile(PREFIX_OUTFILE);


### PR DESCRIPTION
The fix here is to honor the local variables in propertyset within the local scope. Below is the bug related to the fix.

[Bug 50179 - Properties declared as "local" are not accessible via propertyset](https://bz.apache.org/bugzilla/show_bug.cgi?id=50179).