### PR TITLE
Jkf 1.10 requires jdk8

### DIFF
--- a/manual/Tasks/ear.html
+++ b/manual/Tasks/ear.html
@@ -143,8 +143,7 @@ attribute to a value other than its default, <q>add</q>.</strong></p>
     <td>index</td>
     <td>whether to create
       an <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#JAR_Index"
-      target="_top">index list</a> to speed up classloading.  This is a JDK 1.3+ specific feature.
-      Unless you specify additional jars with
+      target="_top">index list</a> to speed up classloading.  Unless you specify additional jars with
       nested <a href="jar.html#indexjars"><code>indexjars</code></a> elements, only the contents of
       this jar will be included in the index.</td>
     <td>No; defaults to <q>false</q></td>

--- a/manual/Tasks/exec.html
+++ b/manual/Tasks/exec.html
@@ -90,9 +90,6 @@ executed exactly as specified inside a temporary DCL script.  This has some impl
     an <q>@</q>-sign (e.g. <var>executable</var>=<q>@[FOO]BAR.COM</q>), just as you would in a DCL
     script</li>
 </ul>
-<p>For <code>&lt;exec&gt;</code> to work in an environment with a JVM older than version 1.4.1-2 it
-is also <em>required</em> that the logical <code>JAVA$FORK_SUPPORT_CHDIR</code> is set
-to <code>TRUE</code> in the job table (see the <em>JDK Release Notes</em>).</p>
 
 <p>Please note that JVM provided by HP doesn't follow OpenVMS' conventions of exit codes.  If you
 run a JVM with this task, the task may falsely claim that an error occurred (or silently ignore an

--- a/manual/Tasks/jar.html
+++ b/manual/Tasks/jar.html
@@ -202,7 +202,7 @@ e.g. decreasing the size by deleting 'same' classes from the versions-branches, 
     <td>index</td>
     <td>whether to create
       an <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#JAR_Index"
-      target="_top">index list</a> to speed up classloading.  This is a JDK 1.3+ specific feature.
+      target="_top">index list</a> to speed up classloading.
       Unless you specify additional jars with nested <a href="#indexjars"><code>indexjars</code></a>
       elements, only the contents of this jar will be included in the index.</td>
     <td>No; defaults to <q>false</q></td>
@@ -508,7 +508,7 @@ Sealed: false</pre>
 <h4>Service Provider</h4>
 
 <p>The following shows how to create a jar file specifying a service with an implementation of the
-JDK 6 scripting interface:</p>
+scripting interface:</p>
 <pre>
 &lt;jar destfile="pinky.jar"&gt;
     &lt;fileset dir="build/classes"/&gt;
@@ -517,7 +517,7 @@ JDK 6 scripting interface:</p>
 &lt;/jar&gt;</pre>
 
 <p>The following shows how to create a jar file specifying a service with two implementations of the
-JDK 6 scripting interface:</p>
+scripting interface:</p>
 <pre>
 &lt;jar destfile="pinkyandbrain.jar"&gt;
     &lt;fileset dir="classes"/&gt;

--- a/manual/Tasks/javac.html
+++ b/manual/Tasks/javac.html
@@ -73,7 +73,7 @@ for either the <code>build.compiler</code> property or the <var>compiler</var> a
   <li><q>sj</q> (Symantec Java compiler) &ndash; <q>symantec</q> can be used as an alias.</li>
   <li><q>extJavac</q> (run either modern or classic in a JVM of its own).</li>
 </ul>
-<p>The default is <q>javac1.x</q> with <q>x</q> depending on the JDK version you use while you are
+<p>The default is <q>javacX</q> with <q>X</q> depending on the JDK version you use while you are
 running Ant.  If you wish to use a different compiler interface than those supplied, you can write a
 class that implements the CompilerAdapter interface
 (package <code>org.apache.tools.ant.taskdefs.compilers</code>). Supply the full classname in
@@ -93,7 +93,7 @@ it passes to the compiler.</p>
 locks up the files present in the classpath of the <code>&lt;javac&gt;</code> task, and does not
 release them.  The side effect of this is that you will not be able to delete or move those files
 later on in the build.  The workaround is to fork when invoking the compiler.</p>
-<p>If you are using Java 8 or above and your source contains native methods or fields annotated with
+<p>If your source contains native methods or fields annotated with
 the <code>@Native</code> annotation you can set the <var>nativeheaderdir</var> attribute in order to
 use the <kbd>-h</kbd> switch of <kbd>javac</kbd> to generate the native header files. Note that
 the logic Ant uses to determine which files to compile does not take native headers into account,
@@ -404,14 +404,14 @@ file will not get compiled even if a native header file generated for it would b
   <tr>
     <td>nativeheaderdir</td>
     <td>Specify where to place generated native header files.  <em>Since Ant 1.9.8</em>.
-    <td>No, ignored when running on JDK 7 or earlier</td>
+    <td>No, ignored when compiling on JDK 7 or earlier</td>
   </tr>
   <tr>
     <td>release</td>
     <td>Specify the value for the <kbd>--release</kbd> switch.<br/>When set and running on JDK 9+
       the <var>source</var> and <var>target</var> attributes as well as the <var>bootclasspath</var>
       will be ignored.  <em>Since Ant 1.9.8</em>.
-    <td>No, ignored when running on JDK 8 or earlier</td>
+    <td>No, ignored when compiling on JDK 8 or earlier</td>
   </tr>
 </table>
 
@@ -590,10 +590,6 @@ log, that these settings are fix.</p>
        executable=&quot;path-to-java14-home/bin/javac&quot;
        fork=&quot;true&quot;
        taskname=&quot;javac1.4&quot;/&gt;</pre>
-
-<p><strong>Note</strong>: If you are using Ant on Windows and a new DOS window pops up for every use
-of an external compiler, this may be a problem of the JDK you are using.  This problem may occur
-with all JDKs prior to 1.2.</p>
 
 <p>If you want to activate other compiler options like <code>lint</code> you could use
 the <code>&lt;compilerarg&gt;</code> element:</p>

--- a/manual/Tasks/javadoc.html
+++ b/manual/Tasks/javadoc.html
@@ -50,12 +50,6 @@ listed in <var>packagelist</var> are not checked, so the task performs even if s
 missing or broken. Use this option if you wish to convert from an existing makefile. Once things are
 running you should then switch to the regular notation.</p>
 
-<p>In the table below, 1.2 means available if your current JVM is exactly of version 1.2 (not 1.3 or
-later), 1.4+ for any JVM of at least version 1.4, otherwise any JVM of at least version 1.2 is
-acceptable. <em>JDKs prior to 1.4 are no longer supported.</em>  If you specify
-the <var>executable</var> attribute it is up to you to ensure that this command supports the
-attributes you wish to use.</p>
-
 <p><strong>Note</strong>: When generating the JavaDocs for classes which contains annotations you
 maybe get a <code class="output">java.lang.ClassCastException:
 com.sun.tools.javadoc.ClassDocImpl</code>.  This is
@@ -82,13 +76,11 @@ with the <var>exclude</var> patterns of the <code>packageset</code> (and vice ve
   <tr>
     <th scope="col">Attribute</th>
     <th scope="col">Description</th>
-    <th scope="col">Availability on Java</th>
     <th scope="col">Required</th>
   </tr>
   <tr>
     <td>sourcepath</td>
     <td>Specify where to find source files</td>
-    <td>all</td>
     <td rowspan="4">At least one of the four or
       nested <code>&lt;sourcepath&gt;</code>, <code>&lt;fileset&gt;</code>,
       <code>module</code> or <code>&lt;packageset&gt;</code></td>
@@ -97,62 +89,52 @@ with the <var>exclude</var> patterns of the <code>packageset</code> (and vice ve
     <td>sourcepathref</td>
     <td>Specify where to find source files by <a href="../using.html#references">reference</a> to a
       <var>sourcepath</var> defined elsewhere.</td>
-    <td class="left">all</td>
   </tr>
   <tr>
     <td>sourcefiles</td>
     <td>Comma separated list of source files&mdash;see also the nested <code>source</code>
       element.</td>
-    <td class="left">all</td>
   </tr>
   <tr>
     <td>modulenames</td>
     <td>Comma separated list of module names -- see also
     the nested <code>module</code> element. <em>since Ant 1.10.6</em></td>
-    <td>all</td>
   </tr>
   <tr>
     <td>destdir</td>
     <td>Destination directory for output files</td>
-    <td>all</td>
     <td>Yes, unless a <var>doclet</var> has been specified.</td>
   </tr>
   <tr>
     <td>maxmemory</td>
     <td>Max amount of memory to allocate to the <kbd>javadoc</kbd> JVM</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>packagenames</td>
     <td>Comma separated list of package files (with terminating wildcard)&mdash;see also the
       nested <code>package</code> element.</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>packageList</td>
     <td>The name of a file containing the packages to process</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>classpath</td>
     <td>Specify where to find user class files</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>Bootclasspath</td>
     <td>Override location of class files loaded by the bootstrap class loader</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>classpathref</td>
     <td>Specify where to find user class files by <a href="../using.html#references">reference</a>
       to a <var>classpath</var> defined elsewhere.</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
@@ -160,136 +142,114 @@ with the <var>exclude</var> patterns of the <code>packageset</code> (and vice ve
     <td>Override location of class files loaded by the bootstrap class loader
       by <a href="../using.html#references">reference</a> to a <var>bootclasspath</var> defined
       elsewhere.</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>Extdirs</td>
     <td>Override location of installed extensions</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>Overview</td>
     <td>Read overview documentation from HTML file</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>access</td>
     <td>Access mode: one of <q>public</q>, <q>protected</q>, <q>package</q>, or <q>private</q></td>
-    <td>all</td>
     <td>No; default is <q>protected</q></td>
   </tr>
   <tr>
     <td>Public</td>
     <td>Show only public classes and members</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>Protected</td>
     <td>Show protected/public classes and members (default)</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>Package</td>
     <td>Show package/protected/public classes and members</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>Private</td>
     <td>Show all classes and members</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>Old</td>
-    <td>Generate output using JDK 1.1 emulating doclet.<br/><strong>Note</strong>: <em>Since Ant
-      1.8.0</em> this attribute has no effect because <kbd>javadoc</kbd> of Java 1.4 and later
-      does not support the <kbd>-1.1</kbd> switch anymore.</td>
-    <td>1.2</td>
+    <td>Generate output using JDK 1.1 emulating doclet.<br/><strong>Note</strong>:
+      This attribute has no effect unless you're using an pre jdk 1.4 external <kbd>javadoc</kbd> 
+   </td>
     <td>No</td>
   </tr>
   <tr>
     <td>Verbose</td>
     <td>Output messages about what <kbd>javadoc</kbd> is doing</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>Locale</td>
     <td>Locale to be used, e.g. <q>en_US</q> or <q>en_US_WIN</q></td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>Encoding</td>
     <td>Source file encoding name</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>Version</td>
     <td>Include <code>@version</code> paragraphs</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>Use</td>
     <td>Create class and package usage pages</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>Author</td>
     <td>Include <code>@author</code> paragraphs</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>Splitindex</td>
     <td>Split index into one file per letter</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>Windowtitle</td>
     <td>Browser window title for the documentation (text)</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>Doctitle</td>
     <td>Include title for the package index (first) page (HTML code)</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>Header</td>
     <td>Include header text for each page (HTML code)</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>Footer</td>
     <td>Include footer text for each page (HTML code)</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>bottom</td>
     <td>Include bottom text for each page (HTML code)</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>link</td>
     <td>Create links to <code>javadoc</code> output at the given URL&mdash;see also the
       nested <code>link</code> element.</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
@@ -298,7 +258,6 @@ with the <var>exclude</var> patterns of the <code>packageset</code> (and vice ve
       at <samp><em>alt-url</em></samp> by specifying a
       value <q><em>url</em>&nbsp;<em>alt-url</em></q> (space as separator). A shorthand for the
       nested <code>link</code> element with <var>offline</var>=<q>true</q>.</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
@@ -306,94 +265,79 @@ with the <var>exclude</var> patterns of the <code>packageset</code> (and vice ve
     <td>Group specified packages together in overview page.  The format is as
       described <a href="#groupattribute">below</a>&mdash;see also the nested <code>group</code>
       element.</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>nodeprecated</td>
     <td>Do not include <code>@deprecated</code> information</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>nodeprecatedlist</td>
     <td>Do not generate deprecated list</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>notree</td>
     <td>Do not generate class hierarchy</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>noindex</td>
     <td>Do not generate index</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>nohelp</td>
     <td>Do not generate help link</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>nonavbar</td>
     <td>Do not generate navigation bar</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>serialwarn</td>
     <td>Generate warning about <code>@serial</code> tag</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>helpfile</td>
     <td>Specifies the HTML help file to use</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>stylesheetfile</td>
     <td>Specifies the CSS stylesheet to use</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>charset</td>
     <td>Charset for cross-platform viewing of generated documentation</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>docencoding</td>
     <td>Output file encoding name</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>doclet</td>
     <td>Specifies the class file that starts the doclet used in generating the
       documentation&mdash;see also the nested <code>doclet</code> element.</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>docletpath</td>
     <td>Specifies the path to the doclet class file that is specified with the <kbd>-doclet</kbd>
       option.</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>docletpathref</td>
     <td>Specifies the path to the doclet class file that is specified with the <kbd>-doclet</kbd>
       option by <a href="../using.html#references">reference</a> to a path defined elsewhere.</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
@@ -401,33 +345,28 @@ with the <var>exclude</var> patterns of the <code>packageset</code> (and vice ve
     <td>Lets you add additional parameters to the <kbd>javadoc</kbd> command line. Useful for
       doclets. Parameters containing spaces need to be quoted using &amp;quot;&mdash;see also the
       nested <code>arg</code> element.</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>failonerror</td>
     <td>Stop the build process if the command exits with a return code other than <q>0</q>.</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>failonwarning</td>
     <td>Stop the build process if a warning is emitted&mdash;i.e. if <kbd>javadoc</kbd>'s output
       contains the word <q>warning</q>.  <em>since Ant 1.9.4</em></td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>excludepackagenames</td>
     <td>comma separated list of packages you don't want docs for&mdash;see also the
       nested <code>excludepackage</code> element.</td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>defaultexcludes</td>
     <td>indicates whether default excludes should be used (<q>yes|no</q>).</td>
-    <td>all</td>
     <td>No; defaults to <q>yes</q></td>
   </tr>
   <tr>
@@ -440,62 +379,54 @@ with the <var>exclude</var> patterns of the <code>packageset</code> (and vice ve
       If enabled, the file will be written to
       the <a href="../running.html#tmpdir">temporary
       directory</a>.</td>
-    <td>all</td>
     <td>No; default is <q>no</q></td>
   </tr>
   <tr>
     <td>source</td>
     <td>Enable <kbd>javadoc</kbd> to handle Java language features.  Set this to <q>1.4</q> to
       document code that compiles using <kbd>javac -source 1.4</kbd>, etc.</td>
-    <td>1.4+</td>
     <td>No; default can be provided using the magic
     <a href="../javacprops.html#source"><code>ant.build.javac.source</code></a> property.</td>
   </tr>
   <tr>
     <td>linksource</td>
     <td>Generate hyperlinks to source files.  <em>since Ant 1.6</em>.  (<q>yes|no</q>).</td>
-    <td>1.4+</td>
     <td>No; default is <q>no</q></td>
   </tr>
   <tr>
     <td>breakiterator</td>
     <td>Use the new break iterator algorithm.  <em>since Ant 1.6</em>.  (<q>yes|no</q>).</td>
-    <td>1.4+</td>
     <td>No; default is <q>no</q></td>
   </tr>
   <tr>
     <td>noqualifier</td>
     <td>Enables the <kbd>-noqualifier</kbd> argument&mdash;must be <q>all</q> or a colon separated
       list of packages.  <em>since Ant 1.6</em>.</td>
-    <td>1.4+</td>
     <td>No</td>
   </tr>
   <tr>
     <td>includenosourcepackages</td>
     <td>If set to <q>true</q>, packages that don't contain Java source but
       a <samp>package.html</samp> will get documented as well.  <em>since Ant 1.6.3</em>.</td>
-    <td>all</td>
     <td>No; default is <q>false</q></td>
   </tr>
   <tr>
     <td>executable</td>
     <td>Specify a particular <kbd>javadoc</kbd> executable to use in place of the default binary
-      (found in the same JDK as Ant is running in).  <em>since Ant 1.6.3</em>.</td>
-    <td>all</td>
+      (found in the same JDK as Ant is running in).  <em>since Ant 1.6.3</em>. <b>Note:</b>
+      <em>It is up to you to ensure that this command supports the attributes you wish to use.</em></td>
     <td>No</td>
   </tr>
   <tr>
     <td>docfilessubdirs</td>
     <td>Enables deep-copying of <samp>doc-files</samp> subdirectories. <em>since Ant
       1.8.0</em>.</td>
-    <td>1.4</td>
     <td>No; defaults to <q>false</q></td>
   </tr>
   <tr>
     <td>excludedocfilessubdir</td>
     <td>Colon-separated list of <samp>doc-files</samp> subdirectories to exclude
       if <var>docfilessubdirs</var> is true. <em>since Ant 1.8.0</em>.</td>
-    <td>1.4</td>
     <td>No</td>
   </tr>
   <tr>
@@ -506,14 +437,12 @@ with the <var>exclude</var> patterns of the <code>packageset</code> (and vice ve
       (<a href="https://www.oracle.com/technetwork/java/javase/7u25-relnotes-1955741.html#jpi-upt"
       target="_top">details</a>).  When this flag is set to <q>true</q>, Ant will check whether the
       docs are vulnerable and will try to fix them.</td>
-    <td>1.4</td>
     <td>No; defaults to <q>true</q></td>
   </tr>
   <tr>
     <td>modulesourcepath</td>
     <td>Specify where to find module source files
       <em>since Ant 1.10.6</em></td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
@@ -521,14 +450,12 @@ with the <var>exclude</var> patterns of the <code>packageset</code> (and vice ve
     <td>Specify where to find module source files by <a
       href="../using.html#references">reference</a> to a PATH defined elsewhere.
       <em>since Ant 1.10.6</em></td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
     <td>modulepath</td>
     <td>Specify where to find module files
       <em>since Ant 1.10.6</em></td>
-    <td>all</td>
     <td>No</td>
   </tr>
   <tr>
@@ -536,7 +463,6 @@ with the <var>exclude</var> patterns of the <code>packageset</code> (and vice ve
     <td>Specify where to find module files by <a
       href="../using.html#references">reference</a> to a PATH defined elsewhere.
       <em>since Ant 1.10.6</em></td>
-    <td>all</td>
     <td>No</td>
   </tr>
 </table>

--- a/manual/Tasks/javah.html
+++ b/manual/Tasks/javah.html
@@ -28,11 +28,7 @@
 <h3>Description</h3>
 <p>Generates JNI headers from a Java class.</p>
 <p>When this task executes, it will generate the C header and source files that are needed to
-implement native methods. JNI operates differently depending on
-whether <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javah.html"
-target="_top">JDK 1.2+</a>
-or <a href="https://web.archive.org/web/20021018232717/http://java.sun.com/products/jdk/1.1/docs/tooldocs/win32/javah.html"
-target="_top">pre-1.2 JDK</a> systems are used.</p>
+implement native methods.
 
 <p>If you are building with Java 8 or above consider
 using <a href="javac.html"><code>javac</code></a>'s <var>nativeheaderdir</var> attribute instead
@@ -86,13 +82,15 @@ done is breaking the amount of classes to compile into smaller chunks.</p>
   </tr>
   <tr>
     <td>force</td>
-    <td>specifies that output files should always be written (JDK 1.2 only)</td>
+    <td>specifies that output files should always be written 
+    (only when using an external javah of JDK 1.2)</td>
     <td>No</td>
   </tr>
   <tr>
     <td>old</td>
     <td>specifies that old JDK 1.0-style header files should be generated (otherwise output file
-      contain JNI-style native method function prototypes) (JDK 1.2 only)</td>
+      contain JNI-style native method function prototypes) 
+      (only when using an external javah of JDK 1.2)</td>
     <td>No</td>
   </tr>
   <tr>

--- a/manual/Tasks/junitreport.html
+++ b/manual/Tasks/junitreport.html
@@ -33,26 +33,6 @@ results.</p>
 distribution. See <a href="../install.html#librarydependencies">Library Dependencies</a> for more
 information.</p>
 
-<h3>Requirements</h3>
-
-<p>The task needs Apache <a href="https://xml.apache.org/xalan-j/" target="_top">Xalan 2.4.1+ or
-Xalan XSLTC</a> (JDK 1.4 contains a version of Xalan 2.x, while JDK 1.5 ships with a version of
-XSLTC). JDK 1.4.2-01 and later ships with a bundled Xalan 2.4.1+, meaning that JDKs prior to version
-1.4.2-01 won't work out of the box. The table below summarize the compatibility status.</p>
-<table>
-<tr><th scope="col">Xalan</th><th scope="col">Sun JDK Bundle</th><th scope="col">Status</th></tr>
-<tr><td>2.4.1+</td><td>JDK 1.4.2-01+</td><td>OK</td></tr>
-<tr><td>XSLTC</td><td>JDK 1.5.x</td><td>OK</td></tr>
-<tr><td>2.x</td><td>JDK 1.4.x</td><td><em><u>Deprecated</u>,
-use <samp>${ant.home}/etc/junit-frames-xalan1.xsl</samp><br/>Upgrade Xalan using the JDK endorsement
-mechanism</em></td></tr>
-</table>
-
-<p>In Ant 1.6.2, we had to decide between supporting Xalan 1/Xalan 2.4.1- and Xalan 2.4.1+/XSLTC,
-because there was no way to support both couples at the same time.</p>
-<p><em>Since Ant 1.7</em>, we dropped support for Xalan 1, because Xalan 1 was not available anymore
-for quite some time.</p>
-
 <h3>Parameters</h3>
 <table class="attr">
   <tr>

--- a/manual/Tasks/script.html
+++ b/manual/Tasks/script.html
@@ -33,8 +33,8 @@ target="_top">JSR 223</a> supported language.
 <p><strong>Note</strong>: This task depends on external libraries not included in the Apache Ant
 distribution.  See <a href="../install.html#librarydependencies">Library Dependencies</a> for more
 information.</p>
-<p>The task may use the BSF scripting manager or the JSR 223 manager that is included in JDK 6 and
-higher. This is controlled by the <var>manager</var> attribute. The JSR 223 scripting manager is
+<p>The task may use the BSF scripting manager or the JSR 223 manager that is included in the JDK.
+This is controlled by the <var>manager</var> attribute. The JSR 223 scripting manager is
 indicated by <q>javax</q>.</p>
 <p>All items (tasks, targets, etc) of the running project are accessible from the script, using
 either their <var>name</var> or <var>id</var> attributes (as long as their names are considered
@@ -81,8 +81,7 @@ In particular all targets should have different location values.</p>
       values: <q>auto</q>, <q>bsf</q> or <q>javax</q>.
       <ul>
         <li><q>bsf</q> use the BSF scripting manager to run the language.</li>
-        <li><q>javax</q> use the <code>javax.scripting</code> manager to run the language. (This
-          will only work for JDK 6 and higher).</li>
+        <li><q>javax</q> use the <code>javax.scripting</code> manager to run the language.</li>
         <li><q>auto</q> use the BSF engine if it exists, otherwise use
           the <code>javax.scripting</code> manager.</li>
       </ul>

--- a/manual/Tasks/splash.html
+++ b/manual/Tasks/splash.html
@@ -75,7 +75,7 @@ that makes it clear to readers of the build exactly what is going on.</p>
   </tr>
   <tr>
     <td>useproxy</td>
-    <td>Use a proxy to access <var>imgurl</var>.<br/>Note: Only tested on JDK 1.2.2 and above</td>
+    <td>Use a proxy to access <var>imgurl</var>.</td>
     <td>No</td>
   </tr>
   <tr>

--- a/manual/Tasks/style.html
+++ b/manual/Tasks/style.html
@@ -29,12 +29,6 @@
 <h3>Description</h3>
 <p>Process a set of documents via XSLT.</p>
 <p>This is useful for building views of XML based documentation, or for generating code.</p>
-<p><strong>Note</strong>: If you are using JDK 1.4 or higher, this task does not require external
-libraries not supplied in the Apache Ant distribution. However, often the built in XSL engine is not
-as up to date as a fresh download, so an update is still highly recommended in particular since the
-built-in XSLT processors of Java 5 (and to a certain extent Java 6) are known to have serious
-issues.  See <a href="../install.html#librarydependencies">Library Dependencies</a> for more
-information.</p>
 <p>It is possible to refine the set of files that are being processed. This can be done with
 the <var>includes</var>, <var>includesfile</var>, <var>excludes</var>, <var>excludesfile</var>
 and <var>defaultexcludes</var> attributes. With the <var>includes</var> or <var>includesfile</var>

--- a/manual/Types/mapper.html
+++ b/manual/Types/mapper.html
@@ -338,13 +338,6 @@ case).</p>
 
 <p>Note that you need to escape a dollar-sign (<q>$</q>) with another dollar-sign in Ant.</p>
 
-<p>The regexp mapper needs a supporting library and an implementation
-of <code class="code">org.apache.tools.ant.util.regexp.RegexpMatcher</code> that hides the specifics
-of the library. <em>Since Ant 1.8.0</em>, Java 1.4 or later is required, so the implementation based
-on the <code class="code">java.util.regex</code> package is always be available.  You can still use
-the now retired Jakarta ORO or Jakarta Regex instead if your provide the corresponding jar in
-your <code>CLASSPATH</code>.</p>
-
 <p>For information about using <a href="https://savannah.gnu.org/projects/gnu-regexp/"
 target="_top">gnu.regexp</a> or <a href="https://github.com/kzn/regex4j/" target="_top">gnu.rex</a>
 with Ant, see <a href="https://marc.info/?l=ant-dev&m=97550753813481&w=2" target="_top">this</a>
@@ -364,7 +357,7 @@ in a nested <code>&lt;classpath&gt;</code>.</p>
 <li>If the system property <code>ant.regexp.matcherimpl</code> has been set, it is taken as the name
 of the class implementing <code class="code">org.apache.tools.ant.util.regexp.RegexpMatcher</code>
 that should be used.</li>
-<li>If it has not been set, uses the JDK 1.4 classes.</li>
+<li>If it has not been set, uses the default from the <code>java.util.regex</code> package.</li>
 </ul>
 
 <h5>Examples</h5>

--- a/manual/Types/regexp.html
+++ b/manual/Types/regexp.html
@@ -57,7 +57,7 @@ Regexp represents a regular expression.
 <h3 id="implementation">Choice of regular expression implementation</h3>
 <p>Apache Ant comes with wrappers for
 the <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/package-summary.html"
-target="_top">java.util.regex
+target="_top"><code>java.util.regex</code>
 package</a>, <a href="https://attic.apache.org/projects/jakarta-regexp.html"
 target="_top">jakarta-regexp</a> and <a href="https://attic.apache.org/projects/jakarta-oro.html"
 target="_top">jakarta-ORO</a>, see <a href="../install.html#librarydependencies">installation
@@ -82,7 +82,7 @@ you rely on it.</p>
 <ul>
   <li>Jakarta Oro defines a line terminator as <q>\n</q> and is consistent with Perl.</li>
   <li>Jakarta RegExp uses a system-dependent line terminator.</li>
-  <li>JDK 1.4 uses <q>\n</q>, <q>\r\n</q>, <q>\u0085</q>, <q>\u2028</q>, <q>\u2029</q> as a
+  <li><code>java.util.regex</code> uses <q>\n</q>, <q>\r\n</q>, <q>\u0085</q>, <q>\u2028</q>, <q>\u2029</q> as a
     default but is configured in the wrapper to use only <q>\n</q> (UNIX_LINE)</li>
 </ul>
 <p><em>We used to recommend that you use Jakarta ORO but since its development has been retired

--- a/manual/develop.html
+++ b/manual/develop.html
@@ -165,9 +165,9 @@ is</p>
     inner <code class="code">AddAsisRemove</code> class used in <code class="code">setCr</code> for
     an example.</li>
 
-  <li>A (Java 5) enumeration, Ant will call the setter with the enum constant matching the value
+  <li>An enumeration, Ant will call the setter with the enum constant matching the value
     given in the build file. This is easier than using <code class="code">EnumeratedAttribute</code>
-    and can result in cleaner code, but of course your task will not run on JDK 1.4 or earlier. Note
+    and can result in cleaner code. Note
     that any override of <code class="code">toString()</code> in the enumeration is ignored; the
     build file must use the declared name (see <code>Enum.getName()</code>). You may wish to use
     lowercase enum constant names, in contrast to usual Java style, to look better in build

--- a/manual/install.html
+++ b/manual/install.html
@@ -242,6 +242,7 @@ The more up-to-date the version of Java, the more Ant tasks you get.
 </p>
 <p>
   <strong>Note</strong>:
+    Ant 1.10.* works with JDK 8 and higher,
     Ant 1.9.* works with JDK 1.5 and higher, Ant 1.8.* works with JDK 1.4 and higher, Ant 1.7.* works with JDK 1.3 and higher,
     Ant 1.6.* works with JDK 1.2 and higher, Ant 1.2 to Ant 1.5.* work with JDK 1.1 and higher.
 </p>

--- a/manual/install.html
+++ b/manual/install.html
@@ -574,19 +574,19 @@ have to spend much time configuring the JVM properties until they are happy.
 <p>Assume Ant is installed in <samp>c:\ant\</samp>. The following sets up the
 environment:</p>
 <pre class="input">set ANT_HOME=c:\ant
-set JAVA_HOME=c:\jdk1.7.0_51
+set JAVA_HOME=c:\jdk11.0.8_10
 set PATH=%PATH%;%ANT_HOME%\bin</pre>
 
 <h3 id="bash">Linux/Unix (bash)</h3>
 <p>Assume Ant is installed in <samp>/usr/local/ant</samp>. The following sets up
 the environment:</p>
 <pre class="input">export ANT_HOME=/usr/local/ant
-export JAVA_HOME=/usr/local/jdk1.7.0_51
+export JAVA_HOME=/usr/local/jdk-11.0.8+10
 export PATH=${PATH}:${ANT_HOME}/bin</pre>
 
 <h3 id="tcshcsh">Linux/Unix (csh)</h3>
 <pre class="input">setenv ANT_HOME /usr/local/ant
-setenv JAVA_HOME /usr/local/jdk/jdk1.7.0_51
+setenv JAVA_HOME=/usr/local/jdk-11.0.8+10
 set path=( $path $ANT_HOME/bin )</pre>
 
 <p>
@@ -778,14 +778,14 @@ these tasks available. Please refer to the <a href="#optionalTasks">Installing A
   <tr>
     <td>jakarta-regexp-1.4.jar</td>
     <td><a href="Types/mapper.html#regexp-mapper">regexp</a> type with mappers (if you do not wish to use
-      java.util.regex)</td>
+      <code>java.util.regex</code>)</td>
     <td><a href="https://attic.apache.org/projects/jakarta-regexp.html"
            target="_top">https://attic.apache.org/projects/jakarta-regexp.html</a></td>
   </tr>
   <tr>
     <td>jakarta-oro-2.0.8.jar</td>
     <td><a href="Types/mapper.html#regexp-mapper">regexp</a> type with mappers (if you do not wish to use
-      java.util.regex) or <a href="Tasks/ftp.html">ftp</a> task with <a href="#commons-net">commons-net</a> 1.4.1</td>
+      <code>java.util.regex</code>) or <a href="Tasks/ftp.html">ftp</a> task with <a href="#commons-net">commons-net</a> 1.4.1</td>
     <td><a href="https://attic.apache.org/projects/jakarta-oro.html"
            target="_top">https://attic.apache.org/projects/jakarta-oro.html</a></td>
   </tr>

--- a/manual/platform.html
+++ b/manual/platform.html
@@ -128,44 +128,6 @@ MacOS X a.k.a. macOS is the first of the Apple platforms that Ant supports compl
 like any other Unix.
 </p>
 
-<h2>Novell Netware</h2>
-<p>
-To give the same level of sophisticated control as Ant's startup scripts on other platforms, it was
-decided to make the main ant startup on NetWare be via a Perl Script, <code>runant.pl</code>.  This
-is found in the <samp>bin</samp> directory (for instance&mdash;<samp>bootstrap\bin</samp>
-or <samp>dist\bin</samp>).
-</p>
-
-<p>One important item of note is that you need to set up the following to run Ant:</p>
-<ul>
-  <li><code>CLASSPATH</code>&mdash;put <samp>ant.jar</samp> and any other needed jars on the system
-    classpath.</li>
-  <li><code>ANT_OPTS</code>&mdash;On NetWare, <code>ANT_OPTS</code> needs to include a parameter of
-    the form, <kbd>-envCWD=<i>ANT_HOME</i></kbd>, with <kbd><i>ANT_HOME</i></kbd> being the
-    fully expanded location of Ant, <strong>not</strong> an environment variable.  This is due to
-    the fact that the NetWare System Console has no notion of a current working directory.</li>
-</ul>
-<p>It is suggested that you create up an <samp>ant.ncf</samp> that sets up these parameters, and
-calls <samp>perl ANT_HOME/dist/bin/runant.pl</samp></p>
-<p>The following is an example of such an NCF file (assuming Ant is installed
-in <samp>sys:/apache-ant/</samp>):</p>
-<pre>
-envset CLASSPATH=sys:/apache-ant/bootstrap/lib/ant.jar
-envset CLASSPATH=$CLASSPATH;sys:/apache-ant/lib/optional/junit.jar
-envset CLASSPATH=$CLASSPATH;sys:/apache-ant/bootstrap/lib/optional.jar
-
-setenv ANT_OPTS=-envCWD=sys:/apache-ant
-envset ANT_OPTS=-envCWD=sys:/apache-ant
-setenv ANT_HOME=sys:/apache-ant/dist/lib
-envset ANT_HOME=sys:/apache-ant/dist/lib
-
-perl sys:/apache-ant/dist/bin/runant.pl</pre>
-
-<p>Ant works on JVM version 1.3 or higher.  You may have some luck running it on JVM 1.2, but
-serious problems have been found running Ant on JVM 1.1.7B.  These problems are caused by JVM bugs
-that will not be fixed.</p>
-<p>JVM 1.3 is supported on Novell NetWare versions 5.1 and higher.</p>
-
 <h2>Other platforms</h2>
 <p>
 Support for other platforms is not guaranteed to be complete, as certain techniques to hide platform

--- a/manual/running.html
+++ b/manual/running.html
@@ -326,7 +326,7 @@ And I filtered out the <code>getPropertyHelper</code> access.</p>
 <tr>
   <td><code>ant.regexp.regexpimpl</code></td>
   <td>classname</td>
-  <td>classname for a RegExp implementation; by default, JDK 1.4+
+  <td>classname for a RegExp implementation; by default the <code>java.util.regex</code>
   implementation; <a href="Types/mapper.html#regexp-mapper">RegExp
   Mapper</a> "Choice of regular expression implementation".</td>
 </tr>

--- a/manual/tutorial-HelloWorldWithAnt.html
+++ b/manual/tutorial-HelloWorldWithAnt.html
@@ -239,8 +239,7 @@ BUILD SUCCESSFUL</pre>
 API&mdash;customizable to a high degree (including switching off during usual life (= not development) execution). We
 use Log4J for that, because</p>
 <ul>
-<li>it is not part of the JDK (1.4+) and we want to show how to use external libs</li>
-<li>it can run under JDK 1.2 (as Ant)</li>
+<li>it is not part of the JDK and we want to show how to use external libs</li>
 <li>it's highly configurable</li>
 <li>it's from Apache ;-)</li>
 </ul>

--- a/manual/tutorial-tasks-filesets-properties.html
+++ b/manual/tutorial-tasks-filesets-properties.html
@@ -658,7 +658,7 @@ After that it prints out the result (e.g. &lt;samp&gt;C:/ant-1.5.4/bin/ant.jar;C
 <li>is the right package used?</li>
 <li>does the code conform to the styleguide?</li>
 <li>do all tests pass?</li>
-<li>does the code compile on JDK 5 (and passes all tests there)?</li>
+<li>does the code compile on the minimal and current JDK for the Ant distribution (and passes all tests there)?</li>
 <li>code under Apache license</li>
 <li>create a patch file</li>
 <li>publishing that patch file</li>
@@ -671,12 +671,12 @@ additional information on that.</p>
 <li>Java file begins with Apache license statement. <strong><em>must do that</em></strong></li>
 <li>Task does not depend on GPL or LGPL code. <strong><em>ok</em></strong></li>
 <li>Source code complies with style guidelines <strong><em>have to check (checkstyle)</em></strong></li>
-<li>Code compiles and runs on Java 5 <strong><em>have to try</em></strong></li>
+<li>Code compiles and runs on minimal support java version <strong><em>have to try</em></strong></li>
 <li>Member variables are private, and provide public accessor methods if access is actually needed. <strong><em>have to
 check (checkstyle)</em></strong></li>
 <li><em>Maybe</em> Task has <var>failonerror</var> attribute to control failure
 behaviour <strong><em>hasn't</em></strong></li>
-<li>New test cases written and succeed <strong><em>passed on JDK 8, have to try on JDK 5</em></strong></li>
+<li>New test cases written and succeed <strong><em>passed on newest jdk version, have to try on oldest supported jdk version</em></strong></li>
 <li>Documentation page written <strong><em>ok</em></strong></li>
 <li>Example task declarations in the documentation tested. <strong><em>ok (used in tests)</em></strong></li>
 <li>Message to dev contains [SUBMIT] and task name in subject <strong><em>to do</em></strong></li>
@@ -764,9 +764,10 @@ after <code>git clone</code> (without our modifications).</p>
 <h3>Apache license statement</h3>
 <p>Simply copy the license text from one the other source from the Ant source tree.</p>
 
-<h3>Test on JDK 5</h3>
-<p>Ant 1.10 uses Java 8 for development, but Ant 1.9 is actively maintained, too.  That means that Ant code must be able
-to run on a JDK 5. So we have to test that. You can download older JDKs
+<h3>Test on the minimal JDK version</h3>
+<p>Ant 1.10 uses Java 8 for development, but Ant 1.9 is actively maintained, too. That means that updates to Ant code 
+present in Ant 1.9 must be able to run on a JDK 5. (It is fine to address only ant 1.10 and above for new teasks.)
+So we have to test that. You can download older JDKs
 from <a href="https://www.oracle.com/technetwork/java/archive-139210.html" target="_top">Oracle [8]</a>.</p>
 
 <p>Clean the <code>ANT_HOME</code> variable, delete the <samp>build</samp>, <samp>bootstrap</samp> and <samp>dist</samp>


### PR DESCRIPTION
Updated the manual to reflect ant 1.10 requires jdk 8

Removed novell from platforms as no current jdk seems to be available for that platform