### PR TITLE
Fix the ant-testutil-sources.jar generation

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -980,7 +980,7 @@
           description="--> creates the Apache Ant Test Utilities source jar">
     <mkdir dir="${build.lib-src}"/>
     <jar destfile="${build.lib-src}/${name}-testutil.jar"
-         basedir="${java.dir}">
+         basedir="${src.junit}">
       <patternset refid="useful.tests"/>
       <metainf dir="${build.dir}">
         <include name="LICENSE.txt"/>


### PR DESCRIPTION
Fixes the issue reported in https://bz.apache.org/bugzilla/show_bug.cgi?id=65110