### PR TITLE
Override ZipOutputStream.write(int)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -166,6 +166,7 @@ Grégoire Vatry
 Günther Kögel
 Harish Prabandham
 Haroon Rafique
+Helder Pereira
 Hiroaki Nakamura
 Holger Engels
 Holger Joest

--- a/contributors.xml
+++ b/contributors.xml
@@ -697,6 +697,10 @@
     <last>Rafique</last>
   </name>
   <name>
+    <first>Helder</first>
+    <last>Pereira</last>
+  </name>
+  <name>
     <first>Hiroaki</first>
     <last>Nakamura</last>
   </name>

--- a/src/main/org/apache/tools/zip/ZipOutputStream.java
+++ b/src/main/org/apache/tools/zip/ZipOutputStream.java
@@ -326,6 +326,11 @@ public class ZipOutputStream extends FilterOutputStream {
     private final Calendar calendarInstance = Calendar.getInstance();
 
     /**
+     * Temporary buffer used for the {@link #write(int)} method.
+     */
+    private final byte[] oneByte = new byte[1];
+
+    /**
      * Creates a new ZIP OutputStream filtering the underlying stream.
      * @param out the outputstream to zip
      * @since 1.1
@@ -899,6 +904,19 @@ public class ZipOutputStream extends FilterOutputStream {
      */
     public boolean canWriteEntryData(ZipEntry ae) {
         return ZipUtil.canHandleEntryData(ae);
+    }
+
+    /**
+     * Writes a byte to ZIP entry.
+     *
+     * @param b the byte to write
+     * @throws IOException on error
+     * @since Ant 1.10.10
+     */
+    @Override
+    public void write(int b) throws IOException {
+        oneByte[0] = (byte) (b & 0xff);
+        write(oneByte, 0, 1);
     }
 
     /**

--- a/src/tests/junit/org/apache/tools/zip/ZipOutputStreamTest.java
+++ b/src/tests/junit/org/apache/tools/zip/ZipOutputStreamTest.java
@@ -21,8 +21,14 @@ package org.apache.tools.zip;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.zip.ZipInputStream;
 
 import static org.junit.Assert.assertEquals;
 
@@ -70,4 +76,18 @@ public class ZipOutputStreamTest {
                      ZipUtil.adjustToLong(2 * Integer.MAX_VALUE));
     }
 
+    @Test
+    public void testWriteAndReadManifest() throws IOException {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+                zos.putNextEntry(new ZipEntry(JarFile.MANIFEST_NAME));
+                new Manifest().write(zos);
+            }
+            try (ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+                 ZipInputStream zis = new ZipInputStream(bais)) {
+                zis.getNextEntry();
+                zis.closeEntry();
+            }
+        }
+    }
 }


### PR DESCRIPTION
`java.util.zip.ZipOutputStream` extends from `java.util.zip.DeflaterOutputStream` which overrides `void write(int b)` to redirect its calls to `void write(byte[] b, int off, int len)`.

`org.apache.tools.zip.ZipOutputStream` doesn't extend the same class and currently doesn't override `void write(int b)`. This means that calls to this method end up in `FilterOutputStream.write(int b)`, which in turn passes them through to the underlying `OutputStream`. This bypasses all the logic in `ZipOutputStream.write(byte[] b, int offset, int len)` (deflation and whatnot) which produces corrupted ZIP files.

One example where the method `void write(int b)` is ultimately invoked is by calling `java.util.jar.Manifest.write(zipOutputStream)`.

This PR fixes this by overriding the method `void write(int b)` in `org.apache.tools.zip.ZipOutputStream` in the same way as `java.util.zip.DeflaterOutputStream` does.