### PR TITLE
correct a typo in the install part of manual (file separator)

### DIFF
--- a/manual/install.html
+++ b/manual/install.html
@@ -36,7 +36,7 @@ details.</li>
 <li>Download Ant. See <a href="#getBinary">Binary Distribution</a> for details.</li>
 <li>Uncompress the downloaded file into a directory.</li>
 <li>Set environmental variables: <code>JAVA_HOME</code> to your Java environment, <code>ANT_HOME</code> to the directory
-you uncompressed Ant to, and add <samp>${ANT_HOME}/bin</samp> (Unix) or <samp>%ANT_HOME%/bin</samp> (Windows) to
+you uncompressed Ant to, and add <samp>${ANT_HOME}/bin</samp> (Unix) or <samp>%ANT_HOME%\bin</samp> (Windows) to
 your <code>PATH</code>. See <a href="#setup">Setup</a> for details.</li>
 <li>Optionally, from the <code>ANT_HOME</code> directory run <kbd>ant -f fetch.xml -Ddest=system</kbd> to get the
 library dependencies of most of the Ant tasks that require them. If you don't do this, many of the dependent Ant tasks


### PR DESCRIPTION
File separator in Windows is backslash instead of slash.