### PR TITLE
Make Watchdog for JUnitLauncherTask customizable.

### DIFF
--- a/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/confined/JUnitLauncherTask.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/confined/JUnitLauncherTask.java
@@ -344,7 +344,8 @@ public class JUnitLauncherTask extends Task {
     private int executeForkedTest(final ForkDefinition forkDefinition, final CommandlineJava commandlineJava) {
         final LogOutputStream outStream = new LogOutputStream(this, Project.MSG_INFO);
         final LogOutputStream errStream = new LogOutputStream(this, Project.MSG_WARN);
-        final ExecuteWatchdog watchdog = forkDefinition.getTimeout() > 0 ? new ExecuteWatchdog(forkDefinition.getTimeout()) : null;
+        final ExecuteWatchdog watchdog = forkDefinition.getTimeout() > 0
+                ? createExecuteWatchdog(forkDefinition.getTimeout()) : null;
         final Execute execute = new Execute(new PumpStreamHandler(outStream, errStream), watchdog);
         execute.setCommandline(commandlineJava.getCommandline());
         execute.setAntRun(getProject());
@@ -363,6 +364,10 @@ public class JUnitLauncherTask extends Task {
             throw new BuildException("Process fork failed", e, getLocation());
         }
         return (watchdog != null && watchdog.killedProcess()) ? Constants.FORK_EXIT_CODE_TIMED_OUT : exitCode;
+    }
+
+    protected ExecuteWatchdog createExecuteWatchdog(long timeout) {
+        return new ExecuteWatchdog(timeout);
     }
 
     private java.nio.file.Path newLaunchDefinitionXml() {


### PR DESCRIPTION
### Context
Currently I'm working on migration of Cassandra to JUnit5 (https://issues.apache.org/jira/browse/CASSANDRA-16630). There is a nice customization that is used there: before terminating a test by timeout, we get all stack traces via `jstack` command. It is very useful for troubleshooting purposes. You can check the reference implementation for JUnit4: https://github.com/apache/cassandra/blob/trunk/test/unit/org/apache/cassandra/JStackJUnitTask.java. Unfortunately it is impossible to do the same customization for `JUnitLauncherTask` (unlikely to `JUnitTask`) because everything is hidden (private) now. We want to have a way to easily extend `Watchdog` created for a task/test monitoring.

### Summary of the changes
1. Moved Watchdog creation into a separate method
2. Made the method protected