### PR TITLE
Fix echoxml example in manual

### DIFF
--- a/manual/Tasks/echoxml.html
+++ b/manual/Tasks/echoxml.html
@@ -59,13 +59,13 @@
 <h3>Examples</h3>
 
 <p>Create an Ant buildfile, <samp>subbuild.xml</samp>.</p>
-<pre>&lt;echoxml file=&quot;subbuild.xml&quot;&gt;
-  &lt;project default=&quot;foo&quot;&gt;
-    &lt;target name=&quot;foo&quot;&gt;
+<pre>&lt;project default=&quot;foo&quot;&gt;
+  &lt;target name=&quot;foo&quot;&gt;
+    &lt;echoxml file=&quot;subbuild.xml&quot;&gt;
       &lt;echo&gt;foo&lt;/echo&gt;
-    &lt;/target&gt;
-  &lt;/project&gt;
-&lt;/echoxml&gt;</pre>
+    &lt;/echoxml&gt;
+  &lt;/target&gt;
+&lt;/project&gt;</pre>
 
 </body>
 </html>


### PR DESCRIPTION
The example of the [echoxml](http://ant.apache.org/manual/Tasks/echoxml.html) task seems to be incorrect. 