### PR TITLE
Ant doesn't call the superclass constructor and pass in the specified parent classloader

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -43,6 +43,7 @@ Avik Sengupta
 Balazs Fejes 2
 barney2k7
 Bart Vanhaute
+Basil Crow
 Ben Galbraith
 Ben Gertzfield
 Benjamin Burgess

--- a/contributors.xml
+++ b/contributors.xml
@@ -200,6 +200,10 @@
     <last>Vanhaute</last>
   </name>
   <name>
+    <first>Basil</first>
+    <last>Crow</last>
+  </name>
+  <name>
     <first>Benjamin</first>
     <last>Burgess</last>
   </name>

--- a/src/main/org/apache/tools/ant/AntClassLoader.java
+++ b/src/main/org/apache/tools/ant/AntClassLoader.java
@@ -273,6 +273,7 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener, Clo
      * @param classpath The classpath to use to load classes.
      */
     public AntClassLoader(final ClassLoader parent, final Project project, final Path classpath) {
+        super(parent);
         setParent(parent);
         setClassPath(classpath);
         setProject(project);
@@ -297,6 +298,7 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener, Clo
      *                elements are set up to start with.
      */
     public AntClassLoader(final Project project, final Path classpath) {
+        super(parent);
         setParent(null);
         setProject(project);
         setClassPath(classpath);


### PR DESCRIPTION
See [JENKINS-21579](https://issues.jenkins.io/browse/JENKINS-21579) and [JENKINS-22310](https://issues.jenkins.io/browse/JENKINS-22310). Back in 2014, Kohsuke Kawaguchi (the creator of Jenkins) forked `AntClassLoader` from Ant 1.8.3 into Jenkins core to apply [the following fix](https://github.com/jenkinsci/jenkins/commit/9a2882dd70) to it:

```
commit 9a2882dd70 (tag: changes/76)
Author: Kohsuke Kawaguchi <kk@kohsuke.org>
Date:   Mon Mar 24 23:04:54 2014

    [FIXED JENKINS-21579] UberClassLoader.findResources() improvements
    
    This is just a locally patched version, so not meant to be used outside
    core.
```

I am now looking into unforking `AntClassLoader` in Jenkins core so that we can reuse the latest upstream version from Ant 1.10.x. As far as I can tell the fix remains valid and should be contributed upstream.

[This comment](https://issues.jenkins.io/browse/JENKINS-22310?focusedCommentId=197405&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-197405) specifically contains Kohsuke's analysis describing the cause of the problem and the motivation for the fix.

This fix has been battle tested on every Jenkins installation for the past 7 years.