### PR TITLE
Implement `ClassLoader#findResource(String)`

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -43,6 +43,7 @@ Avik Sengupta
 Balazs Fejes 2
 barney2k7
 Bart Vanhaute
+Basil Crow
 Ben Galbraith
 Ben Gertzfield
 Benjamin Burgess

--- a/contributors.xml
+++ b/contributors.xml
@@ -200,6 +200,10 @@
     <last>Vanhaute</last>
   </name>
   <name>
+    <first>Basil</first>
+    <last>Crow</last>
+  </name>
+  <name>
     <first>Benjamin</first>
     <last>Burgess</last>
   </name>

--- a/src/main/org/apache/tools/ant/AntClassLoader.java
+++ b/src/main/org/apache/tools/ant/AntClassLoader.java
@@ -889,15 +889,7 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener, Clo
         if (url != null) {
             log("Resource " + name + " loaded from parent loader", Project.MSG_DEBUG);
         } else {
-            // try and load from this loader if the parent either didn't find
-            // it or wasn't consulted.
-            for (final File pathComponent : pathComponents) {
-                url = getResourceURL(pathComponent, name);
-                if (url != null) {
-                    log("Resource " + name + " loaded from ant loader", Project.MSG_DEBUG);
-                    break;
-                }
-            }
+            url = getUrl(name);
         }
         if (url == null && !isParentFirst(name)) {
             // this loader was first but it didn't find it - try the parent
@@ -913,6 +905,29 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener, Clo
         if (url == null) {
             log("Couldn't load Resource " + name, Project.MSG_DEBUG);
         }
+        return url;
+    }
+
+    /**
+     * Finds a matching file by iterating through path components.
+     *
+     * @param name File to find
+     * @return A <code>URL</code> object for reading the resource, or <code>null</code> if the
+     *     resource could not be found
+     */
+    private URL getUrl(String name) {
+        URL url = null;
+
+        // try and load from this loader if the parent either didn't find
+        // it or wasn't consulted.
+        for (final File pathComponent : pathComponents) {
+            url = getResourceURL(pathComponent, name);
+            if (url != null) {
+                log("Resource " + name + " loaded from ant loader", Project.MSG_DEBUG);
+                break;
+            }
+        }
+
         return url;
     }
 
@@ -933,6 +948,18 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener, Clo
     public Enumeration<URL> getNamedResources(final String name)
         throws IOException {
         return findResources(name, false);
+    }
+
+    /**
+     * Finds the resource with the given name.
+     *
+     * @param name The resource name
+     * @return A <code>URL</code> object for reading the resource, or <code>null</code> if the
+     *     resource could not be found
+     */
+    @Override
+    protected URL findResource(final String name) {
+        return getUrl(name);
     }
 
     /**


### PR DESCRIPTION
The [Javadoc for `ClassLoader#findResource(String)`](https://docs.oracle.com/javase/8/docs/api/java/lang/ClassLoader.html#findResource-java.lang.String-) states:

> Class loader implementations should override this method to specify where to find resources.

`AntClassLoader` doesn't do this. Jenkins needed this back in 2011, so Kohsuke Kawaguchi (the creator of Jenkins) implemented a workaround in [this Jenkins core commit](https://github.com/jenkinsci/jenkins/commit/601cb6bb43):

```
commit 601cb6bb43
Author: Kohsuke Kawaguchi <kk@kohsuke.org>
Date:   Mon Oct 10 02:49:45 2011

    implement findResource(
```

I am now looking into unforking `AntClassLoader` in Jenkins core so that we can reuse the latest upstream version from Ant 1.10.x. As far as I can tell the fix remains valid and should be contributed upstream.

This fix is trivial: factoring out the existing implementation used in `getResource` so that it can also be used to implement `findResource`.

This fix has been battle tested on every Jenkins installation for the past 7 years.