### PR TITLE
findResources(String, boolean) can unnecessarily search the parent

### DIFF
--- a/src/main/org/apache/tools/ant/AntClassLoader.java
+++ b/src/main/org/apache/tools/ant/AntClassLoader.java
@@ -936,9 +936,6 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener, Clo
      * data (images, audio, text, etc) that can be accessed by class
      * code in a way that is independent of the location of the code.
      *
-     * <p>Would override getResources if that wasn't final in Java
-     * 1.4.</p>
-     *
      * @param name name of the resource
      * @return possible URLs as enumeration
      * @throws IOException if something goes wrong
@@ -982,26 +979,21 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener, Clo
      *
      * @param name The resource name to search for.
      *             Must not be <code>null</code>.
-     * @param parentHasBeenSearched whether ClassLoader.this.parent
-     * has been searched - will be true if the method is (indirectly)
-     * called from ClassLoader.getResources
+     * @param skipParent whether to skip searching the parent first - will be false if the method is
+     *     invoked from {@link #getResources(String)} or {@link #getNamedResources(String)} and true
+     *     if the method is invoked from {@link #findResources(String)}.
      * @return an enumeration of URLs for the resources
      * @exception IOException if I/O errors occurs (can't happen)
      */
     protected Enumeration<URL> findResources(final String name,
-                                             final boolean parentHasBeenSearched)
+                                             final boolean skipParent)
         throws IOException {
         final Enumeration<URL> mine = new ResourceEnumeration(name);
         Enumeration<URL> base;
-        if (parent != null && (!parentHasBeenSearched || parent != getParent())) {
+        if (parent != null && !skipParent) {
             // Delegate to the parent:
             base = parent.getResources(name);
-            // Note: could cause overlaps in case
-            // ClassLoader.this.parent has matches and
-            // parentHasBeenSearched is true
         } else {
-            // ClassLoader.this.parent is already delegated to for example from
-            // ClassLoader.getResources, no need:
             base = Collections.emptyEnumeration();
         }
         if (isParentFirst(name)) {


### PR DESCRIPTION
See [#149 (comment)](https://github.com/apache/ant/pull/149#issuecomment-884318912). I verified that without this fix, I could reproduce the original problem described by Kohsuke Kawaguchi in [JENKINS-22310 (comment)](https://issues.jenkins.io/browse/JENKINS-22310?focusedCommentId=197405&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-197405). I verified that with this fix, I could no longer reproduce the original problem.