### PR TITLE
Call correct method to get parent from getRootLoader()

### DIFF
--- a/src/main/org/apache/tools/ant/AntClassLoader.java
+++ b/src/main/org/apache/tools/ant/AntClassLoader.java
@@ -860,10 +860,18 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener, Clo
      */
     private ClassLoader getRootLoader() {
         ClassLoader ret = getClass().getClassLoader();
-        while (ret != null && ret.getParent() != null) {
-            ret = ret.getParent();
+        while (ret != null && getParent(ret) != null) {
+            ret = getParent(ret);
         }
         return ret;
+    }
+
+    private static ClassLoader getParent(ClassLoader cl) {
+        if (cl instanceof AntClassLoader) {
+            return ((AntClassLoader) cl).getConfiguredParent();
+        } else {
+            return cl.getParent();
+        }
     }
 
     /**


### PR DESCRIPTION
See [#149 (comment)](https://github.com/apache/ant/pull/149#issuecomment-884318912). Similar to what #151 did for `findResources(String, boolean)`, this PR amends `getRootLoader()` to invoke the correct method to get the parent. The `getParent()` method returns the immutable `parent` field from the parent `ClassLoader` class, which is not used by `AntClassLoader`. The correct method is `getConfiguredParent()` (introduced in commit 26f846b83), which returns the mutable `parent` field from the `AntClassLoader` class.

**Untested.**