### PR TITLE
junitlauncher - Support extension attribute for listeners

### DIFF
--- a/manual/Tasks/junitlauncher.html
+++ b/manual/Tasks/junitlauncher.html
@@ -354,7 +354,7 @@
                 If no value is specified for this attribute and the listener implements
                 the <code>org.apache.tools.ant.taskdefs.optional.junitlauncher.TestResultFormatter</code>
                 then the file name will be defaulted to and will be of the
-                form <code>TEST-<i>testname</i>.<i>formatter-specific-extension</i></code>
+                form <code>TEST-<i>testname</i>.<i>extension</i></code>
                 (ex: <samp>TEST-org.myapp.SomeTest.xml</samp> for the <q>legacy-xml</q> type
                 formatter)
             </p>
@@ -365,6 +365,13 @@
             </p>
         </td>
         <td>No</td>
+    </tr>
+    <tr>
+        <td>extension</td>
+        <td>Extension to append to the output filename.
+            <p><em>Since Ant 1.10.13</em></p>
+        </td>
+        <td>No; defaults to <q>xml</q> for the <q>legacy-xml</q> formatter and to <q>txt</q> for the rest</td>
     </tr>
     <tr>
         <td>outputDir</td>
@@ -406,10 +413,10 @@
     <tr>
         <td>useLegacyReportingName</td>
         <td>Set to true, if the test identifiers reported by this listener should use legacy (JUnit4
-            style) names. Else set to false. Defaults to true.
+            style) names. Else set to false.
             <p><em>Since Ant 1.10.10</em></p>
         </td>
-        <td>No</td>
+        <td>No; defaults to <q>true</q></td>
     </tr>
 </table>
 

--- a/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/LauncherSupport.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/LauncherSupport.java
@@ -282,13 +282,7 @@ public class LauncherSupport {
             final StringBuilder sb = new StringBuilder("TEST-");
             sb.append(testRequest.getName() == null ? "unknown" : testRequest.getName());
             sb.append(".");
-            final String suffix;
-            if ("org.apache.tools.ant.taskdefs.optional.junitlauncher.LegacyXmlResultFormatter".equals(listener.getClassName())) {
-                suffix = "xml";
-            } else {
-                suffix = "txt";
-            }
-            sb.append(suffix);
+            sb.append(listener.getExtension());
             filename = sb.toString();
         }
         if (listener.getOutputDir() != null) {

--- a/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/confined/ListenerDefinition.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/confined/ListenerDefinition.java
@@ -49,6 +49,7 @@ public class ListenerDefinition {
     private String unlessProperty;
     private String className;
     private String resultFile;
+    private String extension = "txt";
     private boolean sendSysOut;
     private boolean sendSysErr;
     private String outputDir;
@@ -94,6 +95,7 @@ public class ListenerDefinition {
             }
             case LEGACY_XML: {
                 this.setClassName("org.apache.tools.ant.taskdefs.optional.junitlauncher.LegacyXmlResultFormatter");
+                this.setExtension("xml");
                 break;
             }
         }
@@ -105,6 +107,20 @@ public class ListenerDefinition {
 
     public String getResultFile() {
         return this.resultFile;
+    }
+
+    /**
+     * Sets the output file extension for this listener.
+     *
+     * @param extension file extension to use
+     * @since Ant 1.10.13
+     */
+    public void setExtension(String extension) {
+        this.extension = extension;
+    }
+
+    public String getExtension() {
+        return extension;
     }
 
     public void setSendSysOut(final boolean sendSysOut) {


### PR DESCRIPTION
### Context
I'm working on migration of Cassandra to JUnit5 (https://issues.apache.org/jira/browse/CASSANDRA-16630). Our test running code is heavily customized and one of the features we rely on is "extension" attribute (https://github.com/apache/ant/blob/master/src/main/org/apache/tools/ant/taskdefs/optional/junit/FormatterElement.java#L77). Unfortunately, _junitlauncher_ task does not have any equivalent. The purpose of this change is to introduce a way to customize output file extension.

### Behavior
Currently `txt` extension is used by default by _junitlauncher_ taks (unlikely to _junit_ task). This PR preserves the existing behavior.

### Summary of the changes
1. Introduced `extension` attribute for `ListenerDefinition`
2. Updated `LauncherSupport` to supper the new attribute
3. Updated documentation