### PR TITLE
junitlauncher - Fixed extension attribute support for listeners

### DIFF
--- a/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/confined/Constants.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/confined/Constants.java
@@ -48,6 +48,7 @@ public final class Constants {
     public static final String LD_XML_ATTR_SEND_SYS_ERR = "sendSysErr";
     public static final String LD_XML_ATTR_SEND_SYS_OUT = "sendSysOut";
     public static final String LD_XML_ATTR_LISTENER_RESULT_FILE = "resultFile";
+    public static final String LD_XML_ATTR_LISTENER_EXTENSION = "extension";
     public static final String LD_XML_ATTR_LISTENER_USE_LEGACY_REPORTING_NAME = "useLegacyReportingName";
 
 

--- a/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/confined/ListenerDefinition.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/confined/ListenerDefinition.java
@@ -27,6 +27,7 @@ import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 
 import static org.apache.tools.ant.taskdefs.optional.junitlauncher.confined.Constants.LD_XML_ATTR_CLASS_NAME;
+import static org.apache.tools.ant.taskdefs.optional.junitlauncher.confined.Constants.LD_XML_ATTR_LISTENER_EXTENSION;
 import static org.apache.tools.ant.taskdefs.optional.junitlauncher.confined.Constants.LD_XML_ATTR_LISTENER_RESULT_FILE;
 import static org.apache.tools.ant.taskdefs.optional.junitlauncher.confined.Constants.LD_XML_ATTR_LISTENER_USE_LEGACY_REPORTING_NAME;
 import static org.apache.tools.ant.taskdefs.optional.junitlauncher.confined.Constants.LD_XML_ATTR_OUTPUT_DIRECTORY;
@@ -202,6 +203,9 @@ public class ListenerDefinition {
         if (this.resultFile != null) {
             writer.writeAttribute(LD_XML_ATTR_LISTENER_RESULT_FILE, this.resultFile);
         }
+        if (this.extension != null) {
+            writer.writeAttribute(LD_XML_ATTR_LISTENER_EXTENSION, this.extension);
+        }
         writer.writeEndElement();
     }
 
@@ -225,6 +229,10 @@ public class ListenerDefinition {
         final String resultFile = reader.getAttributeValue(null, LD_XML_ATTR_LISTENER_RESULT_FILE);
         if (resultFile != null) {
             listenerDef.setResultFile(resultFile);
+        }
+        final String extension = reader.getAttributeValue(null, LD_XML_ATTR_LISTENER_EXTENSION);
+        if (extension != null) {
+            listenerDef.setExtension(extension);
         }
         final String useLegacyReportingName = reader.getAttributeValue(null,
                 LD_XML_ATTR_LISTENER_USE_LEGACY_REPORTING_NAME);


### PR DESCRIPTION
### Context
It is a continuation of https://github.com/apache/ant/pull/168. Looks like I missed to update `toForkedRepresentation`/`fromForkedRepresentation` methods.