### PR TITLE
Allow ant:get task to disable authentication on redirect.

### DIFF
--- a/manual/Tasks/get.html
+++ b/manual/Tasks/get.html
@@ -92,6 +92,12 @@ the request is relayed to the proxy.</p>
     <td>Yes if <var>username</var> is set</td>
   </tr>
   <tr>
+    <td>authenticateOnRedirect</td>
+    <td>Whether the credentials should also be sent to the new location when a redirect is followed.<br/>
+    <em>since Ant 1.10.13</em></td>
+    <td>No; default is <q>true</q></td>
+  </tr>
+  <tr>
     <td>maxtime</td>
     <td>Maximum time in seconds a single download may take, otherwise it will be interrupted and
       treated like a download error.  <em>Since Ant 1.8.0</em></td>

--- a/src/main/org/apache/tools/ant/taskdefs/Get.java
+++ b/src/main/org/apache/tools/ant/taskdefs/Get.java
@@ -82,6 +82,7 @@ public class Get extends Task {
     private boolean ignoreErrors = false;
     private String uname = null;
     private String pword = null;
+    private boolean authenticateOnRedirect = true; // on by default for backward compatibility
     private long maxTime = 0;
     private int numberRetries = NUMBER_RETRIES;
     private boolean skipExisting = false;
@@ -406,6 +407,16 @@ public class Get extends Task {
     }
 
     /**
+     * If true, credentials are set when following a redirect to a new location.
+     *
+     * @param v "true" to enable sending the credentials on redirect; "false" otherwise
+     * @since Ant 1.10.13
+     */
+    public void setAuthenticateOnRedirect(final boolean v) {
+        this.authenticateOnRedirect = v;
+    }
+
+    /**
      * The time in seconds the download is allowed to take before
      * being terminated.
      *
@@ -685,7 +696,7 @@ public class Get extends Task {
 
         private boolean get() throws IOException, BuildException {
 
-            connection = openConnection(source);
+            connection = openConnection(source, uname, pword);
 
             if (connection == null) {
                 return false;
@@ -735,7 +746,8 @@ public class Get extends Task {
             return true;
         }
 
-        private URLConnection openConnection(final URL aSource) throws IOException {
+        private URLConnection openConnection(final URL aSource, final String uname,
+                                             final String pword) throws IOException {
 
             // set up the URL connection
             final URLConnection connection = aSource.openConnection();
@@ -795,7 +807,9 @@ public class Get extends Task {
                     if (!redirectionAllowed(aSource, newURL)) {
                         return null;
                     }
-                    return openConnection(newURL);
+                    return openConnection(newURL,
+                        authenticateOnRedirect ? uname : null,
+                        authenticateOnRedirect ? pword : null);
                 }
                 // next test for a 304 result (HTTP only)
                 final long lastModified = httpConnection.getLastModified();


### PR DESCRIPTION
Most clients do not send the Authorization header on redirects by default; because of security issues.

The ant:get task instead, always sends the Authorization header to the redirected location.

This PR makes this behavior configurable. The optional attribute "authenticateOnRedirect" can be set to "false".

I'm not a security expert. Therefore I didn't change the default behavior to avoid breaking existing Ant scripts. This means, "authenticateOnRedirect" defaults to "true". But maybe it would be better to change this.

_Example: getting an artifact from AWS CodeArtifact which redirects to a pre signed URL and therefore mustn't contain the Authorization header:_
```
<get src="https://codeartifact-url/..." username="aws" password="<secret>" dest="..." authenticateOnRedirect="false">
  <header name="Accept" value="*/*"/>
</get>
```