### PR TITLE
junitlauncher - Fix an issue in LegacyXmlResultFormatter with ]]> in stacktraces

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -234,6 +234,7 @@
     <or>
       <!-- we need JUnit jupiter engine only in tests where we test the junitlauncher task -->
       <filename name="${optional.package}/junitlauncher/**/JUnitLauncherTaskTest.java"/>
+      <filename name="${optional.package}/junitlauncher/**/LegacyXmlResultFormatterTest.java"/>
       <filename name="org/example/junitlauncher/jupiter/**/*"/>
     </or>
   </selector>
@@ -1222,7 +1223,7 @@
     <copy todir="${src.dist.lib}">
       <fileset dir="${lib.dir}">
         <include name="optional/junit-3.8.2.jar"/>
-        <include name="optional/junit-4.13.1.jar"/>
+        <include name="optional/junit-4.13.2.jar"/>
         <include name="optional/hamcrest-core-1.3.jar"/>
         <include name="optional/hamcrest-library-1.3.jar"/>
         <include name="README"/>

--- a/fetch.xml
+++ b/fetch.xml
@@ -236,6 +236,7 @@ Set -Ddest=LOCATION on the command line
     description="load junitlauncher libraries"
     depends="init">
     <f2 project="org.junit.platform" archive="junit-platform-launcher" />
+    <f2 project="org.junit.platform" archive="junit-platform-testkit" />
   </target>
 
   <target name="junit-engine-jupiter"

--- a/lib/libraries.properties
+++ b/lib/libraries.properties
@@ -63,13 +63,15 @@ jruby.version=1.6.8
 # Note - When updating the junit.version here, make sure to also update the
 # "src-dist" target in build.xml to copy the correct junit 4.x jar
 # into the source distribution
-junit.version=4.13.1
+junit.version=4.13.2
 rhino.version=1.7.11
-junit-platform-launcher.version=1.2.0
+junit-platform-launcher.version=1.8.2
 # Only used for internal tests in Ant project
-junit-vintage-engine.version=5.2.0
+junit-platform-testkit.version=1.8.2
 # Only used for internal tests in Ant project
-junit-jupiter-engine.version=5.2.0
+junit-vintage-engine.version=5.8.2
+# Only used for internal tests in Ant project
+junit-jupiter-engine.version=5.8.2
 jsch.version=0.1.55
 jython.version=2.7.2
 # log4j 1.2.15 requires JMS and a few other Sun jars that are not in the m2 repo

--- a/src/etc/poms/ant-junitlauncher/pom.xml
+++ b/src/etc/poms/ant-junitlauncher/pom.xml
@@ -45,19 +45,25 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.2.0</version>
+            <version>1.8.2</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-testkit</artifactId>
+            <version>1.8.2</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.2.0</version>
+            <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>5.2.0</version>
+            <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/LegacyXmlResultFormatter.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/LegacyXmlResultFormatter.java
@@ -299,7 +299,7 @@ class LegacyXmlResultFormatter extends AbstractJUnitResultFormatter implements T
                 }
                 writeAttribute(writer, ATTR_TYPE, t.getClass().getName());
                 // write out the stacktrace
-                writer.writeCData(StringUtils.getStackTrace(t));
+                this.writeCDataSafely(writer, StringUtils.getStackTrace(t));
             }
             writer.writeEndElement();
         }
@@ -318,7 +318,7 @@ class LegacyXmlResultFormatter extends AbstractJUnitResultFormatter implements T
                 }
                 writeAttribute(writer, ATTR_TYPE, t.getClass().getName());
                 // write out the stacktrace
-                writer.writeCData(StringUtils.getStackTrace(t));
+                this.writeCDataSafely(writer, StringUtils.getStackTrace(t));
             }
             writer.writeEndElement();
         }
@@ -343,6 +343,16 @@ class LegacyXmlResultFormatter extends AbstractJUnitResultFormatter implements T
                 writeCharactersFrom(reader, writer);
             }
             writer.writeEndElement();
+        }
+
+        /**
+         * Write cdata safely (escape special sequence {@code "]]>"})
+         * @param writer The xml writer to use
+         * @param cdata The cdata to write
+         * @see <a href="https://bz.apache.org/bugzilla/show_bug.cgi?id=65833">Bugzilla #65833</a>
+         */
+        private void writeCDataSafely(final XMLStreamWriter writer, final String cdata) throws XMLStreamException {
+            writer.writeCData(cdata.replace("]]>", "]]]]><![CDATA[>"));
         }
 
         private void writeCharactersFrom(final Reader reader, final XMLStreamWriter writer) throws IOException, XMLStreamException {

--- a/src/tests/junit/org/example/junitlauncher/jupiter/JupiterCDataTest.java
+++ b/src/tests/junit/org/example/junitlauncher/jupiter/JupiterCDataTest.java
@@ -1,0 +1,24 @@
+package org.example.junitlauncher.jupiter;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Test class to ensure that CData is properly encoded by legacy-xml
+ */
+class JupiterCDataTest {
+    @Test
+    void testExceptionCData() {
+        fail(new IllegalArgumentException("]]>"));
+    }
+
+    @Test
+    void testAbortedCData() {
+        assumeTrue(Instant.now().isAfter(Instant.MIN), "]]>");
+        fail("We should never reach this");
+    }
+}


### PR DESCRIPTION
[Bugzilla Report 65833](https://bz.apache.org/bugzilla/show_bug.cgi?id=65833)

This occurs when the stacktrace message contains ]]>, which is the CDATA
end code. There is no escape, so it must be replaced with `]]` + `]]>` +
`<![CDATA[` + `>`, which means that the CDATA section is split.