### PR TITLE
Fix integer overflow when parsing SOURCE_DATE_EPOCH

### DIFF
--- a/src/main/org/apache/tools/ant/taskdefs/Tstamp.java
+++ b/src/main/org/apache/tools/ant/taskdefs/Tstamp.java
@@ -82,7 +82,7 @@ public class Tstamp extends Task {
             try {
                 if (epoch != null) {
                     // Value of SOURCE_DATE_EPOCH will be an integer, representing seconds.
-                    d = new Date(Integer.parseInt(epoch) * 1000);
+                    d = new Date(Long.parseLong(epoch) * 1000L);
                     log("Honouring environment variable " + ENV_SOURCE_DATE_EPOCH + " which has been set to " + epoch);
                 }
             } catch(NumberFormatException e) {

--- a/src/tests/antunit/taskdefs/tstamp-test.xml
+++ b/src/tests/antunit/taskdefs/tstamp-test.xml
@@ -75,4 +75,35 @@ public class IsEpochIn1969Here implements Condition {
     <!-- 'iso' overrides 'simple' -->
     <au:assertPropertyEquals name="DSTAMP" value="19720417"/>
   </target>
+
+  <target name="testSourceDateEpoch">
+    <mkdir dir="${input}"/>
+    <mkdir dir="${output}"/>
+    <echo file="${input}/TstampAntunitTest.java"><![CDATA[
+      import org.apache.tools.ant.*;
+      import org.apache.tools.ant.taskdefs.*;
+      public class TstampAntunitTest {
+        public static void main(String[] args) {
+          Task task = new Tstamp();
+          task.setProject(new Project());
+          task.execute();
+          String today = task.getProject().getProperty("TODAY");
+          System.out.println("TODAY is " + today);
+        }
+      }
+    ]]></echo>
+    <javac srcdir="${input}" destdir="${output}"/>
+    <local name="testout"/>
+    <java classname="TstampAntunitTest"
+          failonerror="true"
+          outputproperty="testout"
+          fork="true">
+      <classpath>
+        <pathelement location="${output}"/>
+        <pathelement path="${java.class.path}"/>
+      </classpath>
+      <env key="SOURCE_DATE_EPOCH" value="1650585600"/>
+    </java>
+    <au:assertEquals expected="TODAY is April 22 2022" actual="${testout}"/>
+  </target>
 </project>


### PR DESCRIPTION
Parsing SOURCE_DATE_EPOCH environment variable by Tstamp leads to integer overflow and produces wrong result.

The following example illustrates that:

    <tstamp/>
    <echo>TODAY is ${TODAY}</echo>

This produces the following output:

    [tstamp] Honouring environment variable SOURCE_DATE_EPOCH which has been set to 1650585600
    [echo] TODAY is January 16 1970

Which is incorrect, because timestamp 1650585600 corresponds to April 22 2022.