### PR TITLE
Fix retrieval from non-default repositories

### DIFF
--- a/fetch.xml
+++ b/fetch.xml
@@ -119,8 +119,8 @@ Set -Ddest=LOCATION on the command line
             </not>
           </condition>
         </fail>
-        <resolver:remoterepo url="@{repository}" id="@{id}"/>
         <resolver:resolve>
+          <resolver:remoterepo url="@{repository}" id="@{id}"/>
           <dependencies id="@{archive}.path">
             <dependency groupId="@{project}"
                         artifactId="@{archive}"


### PR DESCRIPTION
Since the `<remoterepo>` tag is not in the scope of the `<resolve>` target, fetching artifacts from repositories different from Maven
Central fails (e.g. JAI).