### PR TITLE
Names end before the first NULL (not the last)

### DIFF
--- a/src/main/org/apache/tools/tar/TarUtils.java
+++ b/src/main/org/apache/tools/tar/TarUtils.java
@@ -286,9 +286,9 @@ public class TarUtils {
                                    final ZipEncoding encoding)
         throws IOException {
 
-        int len = length;
-        for (; len > 0; len--) {
-            if (buffer[offset + len - 1] != 0) {
+        int len = 0;
+        for (; len < length; ++len) {
+            if (buffer[offset + len] == 0) {
                 break;
             }
         }


### PR DESCRIPTION
This fixes parsing of archives produced on macOS.
See the discussion in https://github.com/ibmruntimes/Semeru-Runtimes/issues/15.