### PR TITLE
Fix detection of java.specification.version

### DIFF
--- a/src/script/ant
+++ b/src/script/ant
@@ -369,11 +369,18 @@ else
   fi
 fi
 # Run "java -XshowSettings:properties" and check the output for "java.specification.version" value
-JAVA_SPEC_VERSION=$("$JAVACMD" -XshowSettings:properties 2>&1 | grep "java.specification.version = " | tr -d '[:space:]java.specification.version=')
-if [ "$JAVA_SPEC_VERSION" -ge 18 ]; then
-  # set security manager property to allow calls to System.setSecurityManager() at runtime
-  ANT_OPTS="$ANT_OPTS -Djava.security.manager=allow"
-fi
+JAVA_SPEC_VERSION=$("$JAVACMD" -XshowSettings:properties 2>&1 | sed -n -e 's/[[:space:]]//g' -e 's/^java\.specification\.version=//p')
+case "$JAVA_SPEC_VERSION" in
+  1.*)
+    # Up to and including Java 8, versions are reported as 1.N.
+    ;;
+  *)
+    if [ "$JAVA_SPEC_VERSION" -ge 18 ]; then
+      # set security manager property to allow calls to System.setSecurityManager() at runtime
+      ANT_OPTS="$ANT_OPTS -Djava.security.manager=allow"
+    fi
+    ;;
+esac
 ant_exec_command="exec \"\$JAVACMD\" $ANT_OPTS -classpath \"\$LOCALCLASSPATH\" -Dant.home=\"\$ANT_HOME\" -Dant.library.dir=\"\$ANT_LIB\" $ant_sys_opts org.apache.tools.ant.launch.Launcher $ANT_ARGS -cp \"\$CLASSPATH\""
 if $ant_exec_debug; then
   # using printf to avoid echo line continuation and escape interpretation confusion


### PR DESCRIPTION
The existing use of `tr` doesn't distinguish between Java 8 and Java 18; see https://github.com/apache/ant/commit/bbe6859b2f57a2c9dcb51e269527f3c18a74aa1d#commitcomment-90131350 - this fixes that.