### PR TITLE
Do not treat failure of `System.setSecurityManager` as fatal

### DIFF
--- a/src/main/org/apache/tools/ant/taskdefs/ExecuteJava.java
+++ b/src/main/org/apache/tools/ant/taskdefs/ExecuteJava.java
@@ -151,6 +151,7 @@ public class ExecuteJava implements Runnable, TimeoutObserver {
                 throw new BuildException(
                     "main() method in %s is not declared static", classname);
             }
+            perm.setProject(project);
             if (timeout == null) {
                 run(); //NOSONAR
             } else {
@@ -201,6 +202,7 @@ public class ExecuteJava implements Runnable, TimeoutObserver {
             if (sysProperties != null) {
                 sysProperties.restoreSystem();
             }
+            perm.setProject(null);
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/spotbugs/spotbugs-maven-plugin/issues/423. When running on Java 18+, where `System.setSecurityManager` is not allowed by default, just let in-process Java execution run without a security manager. Normally this is not a big deal; it would only matter if you were running a program which actually tried to `System.exit`, which is much better handled by simply forking.

Verified by applying this patch as well as

```diff
diff --git src/etc/poms/ant/pom.xml src/etc/poms/ant/pom.xml
index 9a96764be..b062bbe63 100644
--- src/etc/poms/ant/pom.xml
+++ src/etc/poms/ant/pom.xml
@@ -343,7 +343,7 @@
     <testResources>
       <testResource>
         <directory>../../../../src/etc/testcases</directory>
-        <filtering>true</filtering>
+        <filtering>false</filtering>
       </testResource>
       <testResource>
         <directory>../../../../src/main</directory>
```

(without which I get errors processing various binary or non-UTF-8 test resources; is this code path not tested during release?) and

```bash
mvnd -f src/etc/poms -am -pl ant -DskipTests install
```

and then patching `spotbugs/spotbugs-maven-plugin` with

```diff
diff --git pom.xml pom.xml
index 3a95e22..ca4ef56 100644
--- pom.xml
+++ pom.xml
@@ -160,7 +160,7 @@
     <spotbugsTag>4.7.3</spotbugsTag>
     <slf4jVersion>2.0.7</slf4jVersion>
 
-    <antVersion>1.10.13</antVersion>
+    <antVersion>1.10.14-SNAPSHOT</antVersion>
     <groovyVersion>4.0.11</groovyVersion>
     <javaparserVersion>3.25.2</javaparserVersion>
 
```

and

```bash
mvn -DskipTests install
```

and then in `jenkinsci/scm-api-plugin` running

```bash
JAVA_HOME=/usr/lib/jvm/java-19-openjdk-amd64 mvn spotbugs:check -Dspotbugs.fork=false -Dspotbugs-maven-plugin.version=4.7.3.5-SNAPSHOT -e
```

(I initially tried to write an IT in `spotbugs-maven-plugin` but failed to reproduce the error there, for reasons unknown.)
