### PR TITLE
bz-67082 fix unintended trimmed string output by pathconvert

### DIFF
--- a/src/main/org/apache/tools/ant/taskdefs/PathConvert.java
+++ b/src/main/org/apache/tools/ant/taskdefs/PathConvert.java
@@ -429,7 +429,7 @@ public class PathConvert extends Task {
         if (property == null) {
             out = new LogOutputStream(this);
         } else {
-            out = new PropertyOutputStream(getProject(), property) {
+            out = new PropertyOutputStream(getProject(), property, false) {
                 @Override
                 public void close() {
                     if (setonempty || size() > 0) {

--- a/src/tests/antunit/taskdefs/pathconvert-test.xml
+++ b/src/tests/antunit/taskdefs/pathconvert-test.xml
@@ -129,4 +129,13 @@
           <pathconvert property="someprop" dest="somefile" refid="testpath" />
       </au:expectfailure>
   </target>
+
+  <target name="testUntrimmedOutput">
+      <pathconvert property="result" dirsep="|">
+          <file file="foo" />
+          <globmapper from="${basedir}/*" to="  *  " handledirsep="true" />
+      </pathconvert>
+      <au:assertPropertyEquals name="result" value="  foo  " />
+  </target>
+
 </project>


### PR DESCRIPTION
PropertyOutputStream by default trims output.

This is undesired in the <pathconvert> use case. Explicitly set it to false.

Fixes regression introduced in 1.10.13 / 90ed3ff6cca8634e38d7c3c82858ce48c9c4be2b.