### PR TITLE
bz-66552 fix Depend task does not handle Dynamic constant pool entries - java.lang.ClassFormatError: Invalid Constant Pool entry Type 17

### DIFF
--- a/src/main/org/apache/tools/ant/taskdefs/optional/depend/constantpool/ConstantPoolEntry.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/depend/constantpool/ConstantPoolEntry.java
@@ -68,6 +68,9 @@ public abstract class ConstantPoolEntry {
     /** Tag value for Method Type entries */
     public static final int CONSTANT_METHODTYPE = 16;
 
+    /** Tag value for Dynamic entries*/
+    public static final int CONSTANT_DYNAMIC = 17;
+
     /** Tag value for InvokeDynamic entries*/
     public static final int CONSTANT_INVOKEDYNAMIC = 18;
 
@@ -165,6 +168,9 @@ public abstract class ConstantPoolEntry {
                 break;
             case CONSTANT_METHODTYPE:
                 cpInfo = new MethodTypeCPInfo();
+                break;
+            case CONSTANT_DYNAMIC:
+                cpInfo = new DynamicCPInfo();
                 break;
             case CONSTANT_INVOKEDYNAMIC:
                 cpInfo = new InvokeDynamicCPInfo();

--- a/src/main/org/apache/tools/ant/taskdefs/optional/depend/constantpool/DynamicCPInfo.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/depend/constantpool/DynamicCPInfo.java
@@ -1,0 +1,84 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.tools.ant.taskdefs.optional.depend.constantpool;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+
+/**
+ * An Dynamic CP Info
+ *
+ */
+public class DynamicCPInfo extends ConstantCPInfo {
+
+    /** Index into the bootstrap methods for the class */
+    private int bootstrapMethodAttrIndex;
+    /** the value of the method descriptor pointed to */
+    private int nameAndTypeIndex;
+    /** the name and type CP info pointed to */
+    private NameAndTypeCPInfo nameAndTypeCPInfo;
+
+    /** Constructor.  */
+    public DynamicCPInfo() {
+        super(CONSTANT_DYNAMIC, 1);
+    }
+
+    /**
+     * read a constant pool entry from a class stream.
+     *
+     * @param cpStream the DataInputStream which contains the constant pool
+     *      entry to be read.
+     * @exception IOException if there is a problem reading the entry from
+     *      the stream.
+     */
+    @Override
+    public void read(DataInputStream cpStream) throws IOException {
+        bootstrapMethodAttrIndex = cpStream.readUnsignedShort();
+        nameAndTypeIndex = cpStream.readUnsignedShort();
+    }
+
+    /**
+     * Print a readable version of the constant pool entry.
+     *
+     * @return the string representation of this constant pool entry.
+     */
+    @Override
+    public String toString() {
+        if (isResolved()) {
+            return "Name = " + nameAndTypeCPInfo.getName() + ", type = "
+                + nameAndTypeCPInfo.getType();
+        }
+        return "BootstrapMethodAttrIndex inx = " + bootstrapMethodAttrIndex
+            + "NameAndType index = " + nameAndTypeIndex;
+    }
+    /**
+     * Resolve this constant pool entry with respect to its dependents in
+     * the constant pool.
+     *
+     * @param constantPool the constant pool of which this entry is a member
+     *      and against which this entry is to be resolved.
+     */
+    @Override
+    public void resolve(ConstantPool constantPool) {
+        nameAndTypeCPInfo
+                = (NameAndTypeCPInfo) constantPool.getEntry(nameAndTypeIndex);
+        nameAndTypeCPInfo.resolve(constantPool);
+        super.resolve(constantPool);
+    }
+
+}


### PR DESCRIPTION
 In cases the Depend task scans a class file with Constant Pool entry Type 17 there was no handling, just fireing an Exception.
 Constant is defined since JDK11, and format is same as InvokeDynamic Type 18.
 Provide Identical handling.