### PR TITLE
Throw BuildExceptions in ReplaceRegExp for IOExceptions and missing files

### DIFF
--- a/src/main/org/apache/tools/ant/taskdefs/optional/ReplaceRegExp.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/ReplaceRegExp.java
@@ -481,10 +481,13 @@ public class ReplaceRegExp extends Task {
                 log("An error occurred processing file: '"
                     + file.getAbsolutePath() + "': " + e.toString(),
                     Project.MSG_ERR);
+                throw new BuildException("An error occurred processing file: '" + file.getAbsolutePath() + "'",
+                                         e, getLocation());
             }
         } else if (file != null) {
             log("The following file is missing: '"
                 + file.getAbsolutePath() + "'", Project.MSG_ERR);
+            throw new BuildException("The following file is missing: '" + file.getAbsolutePath() + "'");
         }
 
         if (resources != null) {
@@ -498,10 +501,13 @@ public class ReplaceRegExp extends Task {
                         log("An error occurred processing file: '"
                             + f.getAbsolutePath() + "': " + e.toString(),
                             Project.MSG_ERR);
+                        throw new BuildException("An error occurred processing file: '" + f.getAbsolutePath() + "'",
+                                                 e, getLocation());
                     }
                 } else {
                     log("The following file is missing: '"
                         + f.getAbsolutePath() + "'", Project.MSG_ERR);
+                    throw new BuildException("The following file is missing: '" + f.getAbsolutePath() + "'");
                 }
             }
         }

--- a/src/main/org/apache/tools/ant/taskdefs/optional/ReplaceRegExp.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/ReplaceRegExp.java
@@ -75,7 +75,8 @@ import org.apache.tools.ant.util.regexp.RegexpUtil;
  *                    match="pattern"
  *                    replace="pattern"
  *                    flags="options"?
- *                    byline="true|false"? &gt;
+ *                    byline="true|false"?
+ *                    failOnError="true|false"? &gt;
  *       regexp?
  *       substitution?
  *       fileset*
@@ -101,6 +102,10 @@ import org.apache.tools.ant.util.regexp.RegexpUtil;
  *                 "true" indicates to perform replacement on a line by line basis
  *                 "false" indicates to perform replacement on the whole file at once.
  *
+ *     failOnError --&gt; Should this task fail if an error occurs (default is false)
+ *                 "true" indicates that this task should fail if an error occurs
+ *                 "false" indicates that this task should continue if an error occurs
+ *
  *  Example:
  *
  *     The following call could be used to replace an old property name in a ".properties"
@@ -123,6 +128,7 @@ public class ReplaceRegExp extends Task {
     private Union resources;
     private RegularExpression regex;
     private Substitution subs;
+    private boolean failonerror = false;
 
     private static final FileUtils FILE_UTILS = FileUtils.getFileUtils();
 
@@ -316,6 +322,15 @@ public class ReplaceRegExp extends Task {
     }
 
     /**
+     * If false, note errors but continue.
+     *
+     * @param failonerror true or false
+     */
+    public void setFailOnError(boolean failonerror) {
+        this.failonerror = failonerror;
+    }
+
+    /**
      * Invoke a regular expression (r) on a string (input) using
      * substitutions (s) for a matching regex.
      *
@@ -481,13 +496,17 @@ public class ReplaceRegExp extends Task {
                 log("An error occurred processing file: '"
                     + file.getAbsolutePath() + "': " + e.toString(),
                     Project.MSG_ERR);
-                throw new BuildException("An error occurred processing file: '" + file.getAbsolutePath() + "'",
-                                         e, getLocation());
+                if (failonerror) {
+                    throw new BuildException("An error occurred processing file: '" + file.getAbsolutePath() + "'",
+                                             e, getLocation());
+                }
             }
         } else if (file != null) {
             log("The following file is missing: '"
                 + file.getAbsolutePath() + "'", Project.MSG_ERR);
-            throw new BuildException("The following file is missing: '" + file.getAbsolutePath() + "'");
+            if (failonerror) {
+                throw new BuildException("The following file is missing: '" + file.getAbsolutePath() + "'");
+            }
         }
 
         if (resources != null) {
@@ -501,13 +520,17 @@ public class ReplaceRegExp extends Task {
                         log("An error occurred processing file: '"
                             + f.getAbsolutePath() + "': " + e.toString(),
                             Project.MSG_ERR);
-                        throw new BuildException("An error occurred processing file: '" + f.getAbsolutePath() + "'",
-                                                 e, getLocation());
+                        if (failonerror) {
+                            throw new BuildException("An error occurred processing file: '" + f.getAbsolutePath() + "'",
+                                                     e, getLocation());
+                        }
                     }
                 } else {
                     log("The following file is missing: '"
                         + f.getAbsolutePath() + "'", Project.MSG_ERR);
-                    throw new BuildException("The following file is missing: '" + f.getAbsolutePath() + "'");
+                    if (failonerror) {
+                        throw new BuildException("The following file is missing: '" + f.getAbsolutePath() + "'");
+                    }
                 }
             }
         }


### PR DESCRIPTION
Currently, if an IOException occurs in ReplaceRegExp or a file is missing, the task logs the error, but does not fail.  This pull request has ReplaceRegExp throw a BuildException if the task encounters an IOException or a file is missing.

A failOnError attribute is also added that only affects these newly thrown BuildExceptions.  Existing BuildExceptions that were thrown won't be affected by the failOnError attribute, and backwards compatibility can be maintained with failOnError=false.