### PR TITLE
Destroy forcibly forked test using SIGKILL

### DIFF
--- a/src/main/org/apache/tools/ant/taskdefs/ExecuteWatchdog.java
+++ b/src/main/org/apache/tools/ant/taskdefs/ExecuteWatchdog.java
@@ -125,7 +125,7 @@ public class ExecuteWatchdog implements TimeoutObserver {
                 // a timeout and not a manual stop then kill it.
                 if (watch) {
                     killedProcess = true;
-                    process.destroy();
+                    process.destroyForcibly();
                 }
             }
         } catch (Exception e) {

--- a/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/LauncherSupport.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/LauncherSupport.java
@@ -649,10 +649,7 @@ public class LauncherSupport {
         @Override
         public void executionStarted(final TestIdentifier testIdentifier) {
             super.executionStarted(testIdentifier);
-            AbstractJUnitResultFormatter.isTestClass(testIdentifier).ifPresent(testClass ->
-                    this.originalSysOut.println("Running " + testClass.getClassName()));
         }
-
 
         private static final double ONE_SECOND = 1000.0;
         // We use this only in the testPlanExecutionFinished method, which

--- a/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/LauncherSupport.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/LauncherSupport.java
@@ -649,7 +649,10 @@ public class LauncherSupport {
         @Override
         public void executionStarted(final TestIdentifier testIdentifier) {
             super.executionStarted(testIdentifier);
+            AbstractJUnitResultFormatter.isTestClass(testIdentifier).ifPresent(testClass ->
+                    this.originalSysOut.println("Running " + testClass.getClassName()));
         }
+
 
         private static final double ONE_SECOND = 1000.0;
         // We use this only in the testPlanExecutionFinished method, which


### PR DESCRIPTION
If the JVM of the monitored forked test hangs then `Process:destroy` might not be effective. On unix systems it will send `SIGINT`. An alternative is to use `Process: destroyForcibly` method to use `SIGKILL`.

Using `SIGKILL` will not allow the monitored process to cleanly shutdown, but the question is if it already timed out then it will probably never do any cleanup.

Alternatively watchdog could try `destroy` first and then `destroyForcibly`.

Comments? 
Thanks!