### PR TITLE
BUG-ID : 59160 , fix extracting host for ipv6 address

### DIFF
--- a/src/main/org/apache/tools/ant/taskdefs/optional/ssh/Scp.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/ssh/Scp.java
@@ -437,7 +437,7 @@ public class Scp extends SSHBase {
 
         // For IPv6 address having more than one ":", it should look for the last occurrence
         final int indexOfPath = uri.lastIndexof(':');
-        if (indexOfPath == -1) {
+        if (indexOfPath <= indexOfAt) {
             throw new BuildException("no remote path in %s", uri);
         }
 

--- a/src/main/org/apache/tools/ant/taskdefs/optional/ssh/Scp.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/ssh/Scp.java
@@ -435,7 +435,8 @@ public class Scp extends SSHBase {
             throw new BuildException("no username was given.  Can't authenticate.");
         }
 
-        final int indexOfPath = uri.indexOf(':', indexOfAt + 1);
+        // For IPv6 address having more than one ":", it should look for the last occurrence
+        final int indexOfPath = uri.lastIndexof(':');
         if (indexOfPath == -1) {
             throw new BuildException("no remote path in %s", uri);
         }


### PR DESCRIPTION
Consider the last occurrence of ':' while getting the indexOfPath as IPv6 address has more than one ':'.