### PR TITLE
Fix PermissionUtils.FileType.of for sym links

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -244,6 +244,7 @@ Kevin Greiner
 Kevin Jackson
 Kevin Ross
 Kevin Z. Grey
+Kien Dang
 Kim Hansen
 Kirk Wylie
 Kristian Rosenvold

--- a/contributors.xml
+++ b/contributors.xml
@@ -1019,6 +1019,10 @@
     <last>Grey</last>
   </name>
   <name>
+    <first>Kien</first>
+    <last>Dang</last>
+  </name>
+  <name>
     <first>Kim</first>
     <last>Hansen</last>
   </name>

--- a/src/main/org/apache/tools/ant/util/PermissionUtils.java
+++ b/src/main/org/apache/tools/ant/util/PermissionUtils.java
@@ -19,6 +19,7 @@ package org.apache.tools.ant.util;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.PosixFileAttributeView;
@@ -219,7 +220,7 @@ public class PermissionUtils {
          */
         public static FileType of(Path p) throws IOException {
             BasicFileAttributes attrs =
-                Files.readAttributes(p, BasicFileAttributes.class);
+                Files.readAttributes(p, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
             if (attrs.isRegularFile()) {
                 return FileType.REGULAR_FILE;
             } else if (attrs.isDirectory()) {

--- a/src/tests/junit/org/apache/tools/ant/util/PermissionUtilsTest.java
+++ b/src/tests/junit/org/apache/tools/ant/util/PermissionUtilsTest.java
@@ -32,6 +32,7 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.util.EnumSet;
 import java.util.Set;
 
+import org.apache.tools.ant.taskdefs.condition.Os;
 import org.apache.tools.ant.types.resources.FileResource;
 import org.apache.tools.ant.types.resources.TarResource;
 import org.apache.tools.ant.types.resources.ZipResource;
@@ -96,7 +97,7 @@ public class PermissionUtilsTest {
 
     @Test
     public void detectsFileTypeOfSymbolicLinkFromPath() throws IOException {
-        if (!System.getProperty("os.name").contains("Windows")) {
+        if (Os.isFamily("unix")) {
             Path symlink = folder.getRoot().toPath().resolve("link.tst");
             Files.createSymbolicLink(symlink, folder.newFile("ant.tst").toPath());
             assertEquals(PermissionUtils.FileType.SYMLINK,

--- a/src/tests/junit/org/apache/tools/ant/util/PermissionUtilsTest.java
+++ b/src/tests/junit/org/apache/tools/ant/util/PermissionUtilsTest.java
@@ -25,6 +25,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.EnumSet;
@@ -90,6 +92,16 @@ public class PermissionUtilsTest {
     public void detectsFileTypeOfDirectoryFromResource() throws IOException {
         assertEquals(PermissionUtils.FileType.DIR,
                      PermissionUtils.FileType.of(new FileResource(folder.newFolder("ant.tst"))));
+    }
+
+    @Test
+    public void detectsFileTypeOfSymbolicLinkFromPath() throws IOException {
+        if (!System.getProperty("os.name").contains("Windows")) {
+            Path symlink = folder.getRoot().toPath().resolve("link.tst");
+            Files.createSymbolicLink(symlink, folder.newFile("ant.tst").toPath());
+            assertEquals(PermissionUtils.FileType.SYMLINK,
+                         PermissionUtils.FileType.of(symlink));
+        }
     }
 
     @Test


### PR DESCRIPTION
Currently `PermissionUtils.FileType.of` returns `REGULAR_FILE` instead of `SYMLINK` for sym links.