### PR TITLE
Update the SPDX ID of license

### DIFF
--- a/src/etc/poms/pom.xml
+++ b/src/etc/poms/pom.xml
@@ -31,7 +31,7 @@
   <description>master POM</description>
   <licenses>
     <license>
-      <name>The Apache Software License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>


### PR DESCRIPTION
Seems the current used `The Apache Software License, Version 2.0` is outdated, and it can't be recognized by Maven Central.

See https://central.sonatype.com/artifact/org.apache.ant/ant/1.10.15

<img width="1169" alt="image" src="https://github.com/user-attachments/assets/e1439c32-7aa6-4b1f-8628-aeb1fbadcfe2" />
