### PR TITLE
differenciate between errors and failures for junitlauncher

### DIFF
--- a/WHATSNEW
+++ b/WHATSNEW
@@ -32,6 +32,10 @@ Fixed bugs:
    path even if it was not a file separator.
    Bugzilla Report 69680
 
+ * <junitlauncher>'s legacy formatters now separate errors from
+   failures like their <junit> counterparts did.
+   Bugzilla Report 69687
+
 Other changes:
 --------------
 

--- a/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/AbstractJUnitResultFormatter.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/AbstractJUnitResultFormatter.java
@@ -19,6 +19,7 @@ package org.apache.tools.ant.taskdefs.optional.junitlauncher;
 
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.util.FileUtils;
+import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.launcher.TestIdentifier;
@@ -186,6 +187,10 @@ abstract class AbstractJUnitResultFormatter implements TestResultFormatter {
                 + AbstractJUnitResultFormatter.this.getClass().getName(), t, Project.MSG_DEBUG));
     }
 
+
+    protected static boolean isFailure(final TestExecutionResult executionResult) {
+        return executionResult.getThrowable().orElse(null) instanceof AssertionError;
+    }
 
     /*
     A "store" for sysout/syserr content that gets sent to the AbstractJUnitResultFormatter.

--- a/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/LegacyPlainResultFormatter.java
+++ b/src/main/org/apache/tools/ant/taskdefs/optional/junitlauncher/LegacyPlainResultFormatter.java
@@ -65,6 +65,7 @@ class LegacyPlainResultFormatter extends AbstractJUnitResultFormatter implements
             final Stats stats = entry.getValue();
             final StringBuilder sb = new StringBuilder("Tests run: ").append(stats.numTestsRun.get());
             sb.append(", Failures: ").append(stats.numTestsFailed.get());
+            sb.append(", Errors: ").append(stats.numTestsWithError.get());
             sb.append(", Skipped: ").append(stats.numTestsSkipped.get());
             sb.append(", Aborted: ").append(stats.numTestsAborted.get());
             sb.append(", Time elapsed: ");
@@ -188,7 +189,11 @@ class LegacyPlainResultFormatter extends AbstractJUnitResultFormatter implements
                     break;
                 }
                 case FAILED: {
-                    sb.append(" FAILED");
+                    if (isFailure(testExecutionResult)) {
+                        sb.append(" FAILED");
+                    } else {
+                        sb.append(" Caused an ERROR");
+                    }
                     appendThrowable(sb, testExecutionResult);
                     break;
                 }
@@ -214,7 +219,11 @@ class LegacyPlainResultFormatter extends AbstractJUnitResultFormatter implements
                 break;
             }
             case FAILED: {
-                parentClassStats.numTestsFailed.incrementAndGet();
+                if (isFailure(testExecutionResult)) {
+                    parentClassStats.numTestsFailed.incrementAndGet();
+                } else {
+                    parentClassStats.numTestsWithError.incrementAndGet();
+                }
                 break;
             }
         }
@@ -264,6 +273,7 @@ class LegacyPlainResultFormatter extends AbstractJUnitResultFormatter implements
         private final TestIdentifier testIdentifier;
         private final AtomicLong numTestsRun = new AtomicLong(0);
         private final AtomicLong numTestsFailed = new AtomicLong(0);
+        private final AtomicLong numTestsWithError = new AtomicLong(0);
         private final AtomicLong numTestsSkipped = new AtomicLong(0);
         private final AtomicLong numTestsAborted = new AtomicLong(0);
         private final long startedAt;

--- a/src/tests/junit/org/apache/tools/ant/taskdefs/optional/junitlauncher/LegacyXmlResultFormatterTest.java
+++ b/src/tests/junit/org/apache/tools/ant/taskdefs/optional/junitlauncher/LegacyXmlResultFormatterTest.java
@@ -20,18 +20,36 @@ package org.apache.tools.ant.taskdefs.optional.junitlauncher;
 import org.apache.tools.ant.Project;
 import org.junit.Test;
 import org.junit.platform.engine.ConfigurationParameters;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
+import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Function;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.sax.SAXSource;
+import javax.xml.transform.stream.StreamSource;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
 public class LegacyXmlResultFormatterTest {
@@ -55,6 +73,56 @@ public class LegacyXmlResultFormatterTest {
         f.sysOutAvailable(ORIG.getBytes(StandardCharsets.UTF_8));
         final String result = finishTest(plan);
         assertThat(result, containsString(ENCODED));
+    }
+
+    @Test
+    public void properlyReportsFailures() throws Exception {
+        properlyReportsFailuresAndErrors(new AssertionError("failed", null), true);
+    }
+
+    @Test
+    public void properlyReportsErrors() throws Exception {
+        properlyReportsFailuresAndErrors(new NullPointerException("failed"), false);
+    }
+
+    private void properlyReportsFailuresAndErrors(Throwable errorOrFailure,
+                                                  boolean shouldBeFailure)
+        throws Exception {
+
+        final TestPlan plan = startTest(false);
+        final TestDescriptor testDescriptor = new DummyTestDescriptor("failure");
+        final TestIdentifier test = TestIdentifier.from(testDescriptor);
+        f.executionStarted(test);
+        final TestExecutionResult testResult = TestExecutionResult.failed(errorOrFailure);
+        f.executionFinished(test, testResult);
+        final String result = finishTest(plan);
+
+        final int expectedFailureCount = shouldBeFailure ? 1 : 0;
+        final int expectedErrorCount = shouldBeFailure ? 0 : 1;
+
+        final StreamSource source = new StreamSource() {
+                @Override
+                public Reader getReader() {
+                    return new StringReader(result);
+                }
+            };
+        final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        final InputSource is = SAXSource.sourceToInputSource(source);
+        final DocumentBuilder b = dbf.newDocumentBuilder();
+        final Document doc = b.parse(is);
+        final Element suite = doc.getDocumentElement();
+        assertThat(suite.getTagName(), equalTo("testsuite"));
+        assertThat(suite.getAttribute("failures"), equalTo(expectedFailureCount + ""));
+        assertThat(suite.getAttribute("errors"), equalTo(expectedErrorCount + ""));
+        final NodeList testCases = suite.getElementsByTagName("testcase");
+        assertThat(testCases.getLength(), equalTo(1));
+        final Node testCase = testCases.item(0);
+        assertThat(testCase, instanceOf(Element.class));
+        final Element testCaseElement = (Element) testCase;
+        NodeList failureElements = testCaseElement.getElementsByTagName("failure");
+        assertThat(failureElements.getLength(), equalTo(expectedFailureCount));
+        NodeList errorElements = testCaseElement.getElementsByTagName("error");
+        assertThat(errorElements.getLength(), equalTo(expectedErrorCount));
     }
 
     private TestPlan startTest(final boolean withProperties) {
@@ -109,6 +177,17 @@ public class LegacyXmlResultFormatterTest {
             f.setDestination(bos);
             f.testPlanExecutionFinished(testPlan);
             return new String(bos.toByteArray(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static class DummyTestDescriptor extends AbstractTestDescriptor {
+        private DummyTestDescriptor(String displayName) {
+            super(UniqueId.forEngine("testengine"), displayName);
+        }
+
+        @Override
+        public TestDescriptor.Type getType() {
+            return TestDescriptor.Type.TEST;
         }
     }
 }


### PR DESCRIPTION
Try to tell errors from failures in junitlaucher's formatters.

@Vampire and @jaikiran I'd like to have a second pair of eyes since I'm not familiar with the JUnit5 API at all.