### PR TITLE
Use StreamSupport and spliterator to create a stream for ResourceCollection

### DIFF
--- a/src/main/org/apache/tools/ant/types/ResourceCollection.java
+++ b/src/main/org/apache/tools/ant/types/ResourceCollection.java
@@ -14,6 +14,7 @@
 package org.apache.tools.ant.types;
 
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * Interface describing a collection of Resources.
@@ -46,9 +47,7 @@ public interface ResourceCollection extends Iterable<Resource> {
      * @since Ant 1.10.2
      */
     default Stream<? extends Resource> stream() {
-        final Stream.Builder<Resource> b = Stream.builder();
-        forEach(b);
-        return b.build();
+        return StreamSupport.stream(spliterator(), false);
     }
 
     /**

--- a/src/main/org/apache/tools/ant/types/ResourceCollection.java
+++ b/src/main/org/apache/tools/ant/types/ResourceCollection.java
@@ -13,8 +13,6 @@
  */
 package org.apache.tools.ant.types;
 
-import java.util.Spliterator;
-import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -42,21 +40,6 @@ public interface ResourceCollection extends Iterable<Resource> {
      * @return whether this is a filesystem-only resource collection.
      */
     boolean isFilesystemOnly();
-
-    /**
-     * Creates a {@link Spliterator} over the elements described by this {@link
-     * ResourceCollection}. The spliterator uses the characteristics of the
-     * underlying {@code ResourceCollection} such as size and assumes the
-     * collection is sized.
-     *
-     * @return a {@code Spliterator} over the elements described by this
-     * {@code ResourceCollection}.
-     * @since Ant 1.10.16
-     */
-    @Override
-    default Spliterator<Resource> spliterator() {
-        return Spliterators.spliterator(iterator(), size(), Spliterator.SIZED);
-    }
 
     /**
      * Return a {@link Stream} over this {@link ResourceCollection}.

--- a/src/main/org/apache/tools/ant/types/ResourceCollection.java
+++ b/src/main/org/apache/tools/ant/types/ResourceCollection.java
@@ -13,6 +13,8 @@
  */
 package org.apache.tools.ant.types;
 
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -40,6 +42,21 @@ public interface ResourceCollection extends Iterable<Resource> {
      * @return whether this is a filesystem-only resource collection.
      */
     boolean isFilesystemOnly();
+
+    /**
+     * Creates a {@link Spliterator} over the elements described by this {@link
+     * ResourceCollection}. The spliterator uses the characteristics of the
+     * underlying {@code ResourceCollection} such as size and assumes the
+     * collection is sized.
+     *
+     * @return a {@code Spliterator} over the elements described by this
+     * {@code ResourceCollection}.
+     * @since Ant 1.10.16
+     */
+    @Override
+    default Spliterator<Resource> spliterator() {
+        return Spliterators.spliterator(iterator(), size(), Spliterator.SIZED);
+    }
 
     /**
      * Return a {@link Stream} over this {@link ResourceCollection}.


### PR DESCRIPTION
I came across this while working on a custom Ant task. I saw what I think is the ResourceCollection stream() method eagerly loading elements when creating a stream. Not sure if that was intentional or not. If it is, feel free to close the PR.  If not, I've created this to update it to use the StreamSupport factory method and a spliterator. I think this is how the JDK Collection creates the stream. This will make using things like findFirst a bit faster as it won't have to load every element to find the first.