### PR TITLE
Removed outdated Microsoft OpenJDK vendor hardcoding which causes errors

### DIFF
--- a/src/main/org/apache/tools/ant/types/Path.java
+++ b/src/main/org/apache/tools/ant/types/Path.java
@@ -608,49 +608,39 @@ public class Path extends DataType implements Cloneable, ResourceCollection {
             addExisting(systemBootClasspath);
         }
 
-        if (System.getProperty("java.vendor").toLowerCase(Locale.ENGLISH).contains("microsoft")) {
-            // TODO is this code still necessary? is there any 1.2+ port?
-            // Pull in *.zip from packages directory
-            FileSet msZipFiles = new FileSet();
-            msZipFiles.setDir(new File(JavaEnvUtils.getJavaHome()
-                    + File.separator + "Packages"));
-            msZipFiles.setIncludes("*.ZIP");
-            addFileset(msZipFiles);
-        } else {
-            // JDK 1.2+ seems to set java.home to the JRE directory.
+        // JDK 1.2+ seems to set java.home to the JRE directory.
+        addExisting(new Path(null, JavaEnvUtils.getJavaHome()
+                + File.separator + "lib" + File.separator + "rt.jar"));
+        // Just keep the old version as well and let addExisting
+        // sort it out.
+        addExisting(new Path(null, JavaEnvUtils.getJavaHome()
+                + File.separator + "jre" + File.separator + "lib"
+                + File.separator + "rt.jar"));
+
+        // Sun's and Apple's 1.4 have JCE and JSSE in separate jars.
+        for (String secJar : Arrays.asList("jce", "jsse")) {
             addExisting(new Path(null, JavaEnvUtils.getJavaHome()
-                    + File.separator + "lib" + File.separator + "rt.jar"));
-            // Just keep the old version as well and let addExisting
-            // sort it out.
-            addExisting(new Path(null, JavaEnvUtils.getJavaHome()
-                    + File.separator + "jre" + File.separator + "lib"
-                    + File.separator + "rt.jar"));
-
-            // Sun's and Apple's 1.4 have JCE and JSSE in separate jars.
-            for (String secJar : Arrays.asList("jce", "jsse")) {
-                addExisting(new Path(null, JavaEnvUtils.getJavaHome()
-                        + File.separator + "lib"
-                        + File.separator + secJar + ".jar"));
-                addExisting(new Path(null, JavaEnvUtils.getJavaHome()
-                        + File.separator + ".." + File.separator + "Classes"
-                        + File.separator + secJar + ".jar"));
-            }
-
-            // IBM's 1.4 has rt.jar split into 4 smaller jars and a combined
-            // JCE/JSSE in security.jar.
-            for (String ibmJar : Arrays.asList("core", "graphics", "security", "server", "xml")) {
-                addExisting(new Path(null, JavaEnvUtils.getJavaHome()
-                        + File.separator + "lib" + File.separator + ibmJar + ".jar"));
-            }
-
-            // Added for MacOS X
+                    + File.separator + "lib"
+                    + File.separator + secJar + ".jar"));
             addExisting(new Path(null, JavaEnvUtils.getJavaHome()
                     + File.separator + ".." + File.separator + "Classes"
-                    + File.separator + "classes.jar"));
-            addExisting(new Path(null, JavaEnvUtils.getJavaHome()
-                    + File.separator + ".." + File.separator + "Classes"
-                    + File.separator + "ui.jar"));
+                    + File.separator + secJar + ".jar"));
         }
+
+        // IBM's 1.4 has rt.jar split into 4 smaller jars and a combined
+        // JCE/JSSE in security.jar.
+        for (String ibmJar : Arrays.asList("core", "graphics", "security", "server", "xml")) {
+            addExisting(new Path(null, JavaEnvUtils.getJavaHome()
+                    + File.separator + "lib" + File.separator + ibmJar + ".jar"));
+        }
+
+        // Added for MacOS X
+        addExisting(new Path(null, JavaEnvUtils.getJavaHome()
+                + File.separator + ".." + File.separator + "Classes"
+                + File.separator + "classes.jar"));
+        addExisting(new Path(null, JavaEnvUtils.getJavaHome()
+                + File.separator + ".." + File.separator + "Classes"
+                + File.separator + "ui.jar"));
     }
 
     /**


### PR DESCRIPTION
This hardcoding has been outdated for a few years. Since then, quite a few GitHub issues have appeared where problems are experienced as a result of this hardcoding. Example: https://github.com/microsoft/openjdk/issues/339

**Note**, the only changes here are:
- I removed the if-statement which adds hardcoding for the Microsoft OpenJDK vendor
- I restored the spacing of everything in the else-statement to be in line with the function